### PR TITLE
chore: support global.priorityClassName

### DIFF
--- a/charts/steadybit-extension-gcp/Chart.yaml
+++ b/charts/steadybit-extension-gcp/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: steadybit-extension-gcp
 description: Steadybit gcp extension Helm chart for Kubernetes.
-version: 1.1.25
+version: 1.1.26
 appVersion: v1.0.19
 home: https://www.steadybit.com/
 icon: https://steadybit-website-assets.s3.amazonaws.com/logo-symbol-transparent.png

--- a/charts/steadybit-extension-gcp/templates/deployment.yaml
+++ b/charts/steadybit-extension-gcp/templates/deployment.yaml
@@ -36,7 +36,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
-      {{- with .Values.priorityClassName }}
+      {{- with (.Values.priorityClassName | default (dig "priorityClassName" nil (.Values.global | default dict))) }}
       priorityClassName: {{ . }}
       {{- end }}
       {{- with .Values.podSecurityContext }}


### PR DESCRIPTION
Support falling back to global.priorityClassName when extension-specific priorityClassName is not set.