### PR TITLE
feat: support if-none-match for the extension list endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## (next)
+
+- Support if-none-match for the extension list endpoint
+
 ## v1.0.20
 
 - feat(chart): split image.name into image.registry + image.name

--- a/main.go
+++ b/main.go
@@ -5,6 +5,8 @@
 package main
 
 import (
+	"time"
+
 	_ "github.com/KimMachineGun/automemlimit" // By default, it sets `GOMEMLIMIT` to 90% of cgroup's memory limit.
 	"github.com/steadybit/action-kit/go/action_kit_api/v2"
 	"github.com/steadybit/action-kit/go/action_kit_sdk"
@@ -18,6 +20,8 @@ import (
 	"github.com/steadybit/extension-kit/extlogging"
 	"github.com/steadybit/extension-kit/extsignals"
 )
+
+var startedAt = time.Now().Format(time.RFC3339)
 
 func main() {
 	// Most Steadybit extensions leverage zerolog. To encourage persistent logging setups across extensions,
@@ -45,13 +49,13 @@ func main() {
 
 	// This call registers a handler for the extension's root path. This is the path initially accessed
 	// by the Steadybit agent to obtain the extension's capabilities.
-	exthttp.RegisterHttpHandler("/", exthttp.GetterAsHandler(getExtensionList))
-
 	// This is a section you will most likely want to change: The registration of HTTP handlers
 	// for your extension. You might want to change these because the names do not fit, or because
 	// you do not have a need for all of them.
 	discovery_kit_sdk.Register(extvm.NewVirtualMachineDiscovery())
 	action_kit_sdk.RegisterAction(extvm.NewVirtualMachineStateAction())
+
+	exthttp.RegisterHttpHandler("/", exthttp.IfNoneMatchHandler(func() string { return startedAt }, exthttp.GetterAsHandler(getExtensionList)))
 
 	//This will install a signal handlder, that will stop active actions when receiving a SIGURS1, SIGTERM or SIGINT
 	extsignals.ActivateSignalHandlers()


### PR DESCRIPTION
## Summary
- Wrap the `"/"` index handler with `exthttp.IfNoneMatchHandler` using a startup timestamp as ETag
- Allows clients to skip re-fetching the unchanged extension list via `If-None-Match` header
- Move index handler registration to after all action/discovery registrations for consistency

## Test plan
- [ ] Verify extension starts and responds to `GET /` with an `ETag` header
- [ ] Verify `GET /` with matching `If-None-Match` header returns `304 Not Modified`

🤖 Generated with [Claude Code](https://claude.com/claude-code)