### PR TITLE
chore: bump Go to 1.26.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
   extension-ci:
     uses: steadybit/extension-kit/.github/workflows/reusable-extension-ci.yml@main # NOSONAR githubactions:S7637 - our own action
     with:
-      go_version: '^1.25.9'
+      go_version: '^1.26.2'
       build_linux_packages: true
       VERSION_BUMPER_APPID: ${{ vars.GH_APP_STEADYBIT_APP_ID }}
     secrets:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## (next)
+
+- Bump Go to 1.26.2
+
 ## v1.0.22
 
 - Bump Go to 1.25.9

--- a/extvm/vm_attack_state.go
+++ b/extvm/vm_attack_state.go
@@ -14,7 +14,6 @@ import (
 	"github.com/steadybit/action-kit/go/action_kit_sdk"
 	extension_kit "github.com/steadybit/extension-kit"
 	"github.com/steadybit/extension-kit/extbuild"
-	"github.com/steadybit/extension-kit/extutil"
 )
 
 type virtualMachineStateAction struct {
@@ -51,34 +50,34 @@ func (e *virtualMachineStateAction) Describe() action_kit_api.ActionDescription 
 		Label:       "Change Virtual Machine State",
 		Description: "Reset, stop, suspend or delete Google Cloud virtual machines",
 		Version:     extbuild.GetSemverVersionStringOrUnknown(),
-		Icon:        extutil.Ptr(targetIcon),
-		TargetSelection: extutil.Ptr(action_kit_api.TargetSelection{
+		Icon:        new(targetIcon),
+		TargetSelection: new(action_kit_api.TargetSelection{
 			TargetType: TargetIDVM,
-			SelectionTemplates: extutil.Ptr([]action_kit_api.TargetSelectionTemplate{
+			SelectionTemplates: new([]action_kit_api.TargetSelectionTemplate{
 				{
 					Label:       "vm-name",
-					Description: extutil.Ptr("Find gcp virtual machine by name"),
+					Description: new("Find gcp virtual machine by name"),
 					Query:       "gcp-vm.name=\"\"",
 				},
 				{
 					Label:       "cluster name",
-					Description: extutil.Ptr("Find gcp virtual machine by cluster name"),
+					Description: new("Find gcp virtual machine by cluster name"),
 					Query:       "gcp-kubernetes-engine.cluster.name=\"\"",
 				},
 			}),
 		}),
-		Technology:  extutil.Ptr("GCP"),
-		Category:    extutil.Ptr("Virtual Machines"),
+		Technology:  new("GCP"),
+		Category:    new("Virtual Machines"),
 		TimeControl: action_kit_api.TimeControlInstantaneous,
 		Kind:        action_kit_api.Attack,
 		Parameters: []action_kit_api.ActionParameter{
 			{
 				Name:        "action",
 				Label:       "Action",
-				Description: extutil.Ptr("The kind of state change operation to execute for the gcp virtual machines"),
-				Required:    extutil.Ptr(true),
+				Description: new("The kind of state change operation to execute for the gcp virtual machines"),
+				Required:    new(true),
 				Type:        action_kit_api.ActionParameterTypeString,
-				Options: extutil.Ptr([]action_kit_api.ParameterOption{
+				Options: new([]action_kit_api.ParameterOption{
 					action_kit_api.ExplicitParameterOption{
 						Label: "Reset",
 						Value: "reset",

--- a/extvm/vm_attack_state_test.go
+++ b/extvm/vm_attack_state_test.go
@@ -27,10 +27,10 @@ func TestGcpVirtualMachineStateAction_Prepare(t *testing.T) {
 		{
 			name: "Should return config",
 			requestBody: extutil.JsonMangle(action_kit_api.PrepareActionRequestBody{
-				Config: map[string]interface{}{
+				Config: map[string]any{
 					"action": "stop",
 				},
-				Target: extutil.Ptr(action_kit_api.Target{
+				Target: new(action_kit_api.Target{
 					Attributes: map[string][]string{
 						"gcp-vm.name":    {"my-vm"},
 						"gcp.project.id": {"42"},
@@ -49,10 +49,10 @@ func TestGcpVirtualMachineStateAction_Prepare(t *testing.T) {
 		{
 			name: "Should return error if project id is missing",
 			requestBody: extutil.JsonMangle(action_kit_api.PrepareActionRequestBody{
-				Config: map[string]interface{}{
+				Config: map[string]any{
 					"action": "stop",
 				},
-				Target: extutil.Ptr(action_kit_api.Target{
+				Target: new(action_kit_api.Target{
 					Attributes: map[string][]string{
 						"gcp-vm.name": {"my-vm"},
 						"gcp.zone":    {"us-central1-a	"},
@@ -64,10 +64,10 @@ func TestGcpVirtualMachineStateAction_Prepare(t *testing.T) {
 		{
 			name: "Should return error if vm name is missing",
 			requestBody: extutil.JsonMangle(action_kit_api.PrepareActionRequestBody{
-				Config: map[string]interface{}{
+				Config: map[string]any{
 					"action": "stop",
 				},
-				Target: extutil.Ptr(action_kit_api.Target{
+				Target: new(action_kit_api.Target{
 					Attributes: map[string][]string{
 						"gcp.project.id": {"42"},
 						"gcp.zone":       {"us-central1-a	"},
@@ -79,10 +79,10 @@ func TestGcpVirtualMachineStateAction_Prepare(t *testing.T) {
 		{
 			name: "Should return error if zone is missing",
 			requestBody: extutil.JsonMangle(action_kit_api.PrepareActionRequestBody{
-				Config: map[string]interface{}{
+				Config: map[string]any{
 					"action": "stop",
 				},
-				Target: extutil.Ptr(action_kit_api.Target{
+				Target: new(action_kit_api.Target{
 					Attributes: map[string][]string{
 						"gcp-vm.name":    {"my-vm"},
 						"gcp.project.id": {"42"},
@@ -94,8 +94,8 @@ func TestGcpVirtualMachineStateAction_Prepare(t *testing.T) {
 		{
 			name: "Should return error if action is missing",
 			requestBody: extutil.JsonMangle(action_kit_api.PrepareActionRequestBody{
-				Config: map[string]interface{}{},
-				Target: extutil.Ptr(action_kit_api.Target{
+				Config: map[string]any{},
+				Target: new(action_kit_api.Target{
 					Attributes: map[string][]string{
 						"gcp-vm.name":    {"my-vm"},
 						"gcp.project.id": {"42"},

--- a/extvm/vm_discovery.go
+++ b/extvm/vm_discovery.go
@@ -45,7 +45,7 @@ func (d *vmDiscovery) Describe() discovery_kit_api.DiscoveryDescription {
 	return discovery_kit_api.DiscoveryDescription{
 		Id: TargetIDVM,
 		Discover: discovery_kit_api.DescribingEndpointReferenceWithCallInterval{
-			CallInterval: extutil.Ptr("30s"),
+			CallInterval: new("30s"),
 		},
 	}
 }
@@ -54,13 +54,13 @@ func (d *vmDiscovery) DescribeTarget() discovery_kit_api.TargetDescription {
 	return discovery_kit_api.TargetDescription{
 		Id:      TargetIDVM,
 		Version: extbuild.GetSemverVersionStringOrUnknown(),
-		Icon:    extutil.Ptr(targetIcon),
+		Icon:    new(targetIcon),
 
 		// Labels used in the UI
 		Label: discovery_kit_api.PluralLabel{One: "Google Cloud Virtual Machine", Other: "Google Cloud Virtual Machines"},
 
 		// Category for the targets to appear in
-		Category: extutil.Ptr("cloud"),
+		Category: new("cloud"),
 
 		// Specify attributes shown in table columns and to be used for sorting
 		Table: discovery_kit_api.Table{

--- a/extvm/vm_discovery_test.go
+++ b/extvm/vm_discovery_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"github.com/googleapis/gax-go/v2"
 	"github.com/steadybit/extension-gcp/config"
-	"github.com/steadybit/extension-kit/extutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"testing"
@@ -31,16 +30,16 @@ func TestInstancesToTargets(t *testing.T) {
 	id := uint64(42)
 	instances := []*computepb.Instance{
 		{
-			Name:               extutil.Ptr("myVm"),
+			Name:               new("myVm"),
 			Id:                 &id,
-			Hostname:           extutil.Ptr("asd"),
-			Description:        extutil.Ptr("description"),
-			CpuPlatform:        extutil.Ptr("intel"),
-			MachineType:        extutil.Ptr("fat"),
-			SourceMachineImage: extutil.Ptr("18.04.5 LTS"),
-			Status:             extutil.Ptr("top"),
-			StatusMessage:      extutil.Ptr("top status"),
-			Zone:               extutil.Ptr("/asd/us-east1-a"),
+			Hostname:           new("asd"),
+			Description:        new("description"),
+			CpuPlatform:        new("intel"),
+			MachineType:        new("fat"),
+			SourceMachineImage: new("18.04.5 LTS"),
+			Status:             new("top"),
+			StatusMessage:      new("top status"),
+			Zone:               new("/asd/us-east1-a"),
 			Tags: &computepb.Tags{
 				Items: []string{"Tags1", "Tags2"},
 			},
@@ -51,12 +50,12 @@ func TestInstancesToTargets(t *testing.T) {
 			Metadata: &computepb.Metadata{
 				Items: []*computepb.Items{
 					{
-						Key:   extutil.Ptr("cluster-name"),
-						Value: extutil.Ptr("my_cluster"),
+						Key:   new("cluster-name"),
+						Value: new("my_cluster"),
 					},
 					{
-						Key:   extutil.Ptr("cluster-location"),
-						Value: extutil.Ptr("us-east1-a"),
+						Key:   new("cluster-location"),
+						Value: new("us-east1-a"),
 					},
 				},
 			},

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/steadybit/extension-gcp
 
-go 1.25.7
+go 1.26.2
 
 require (
 	cloud.google.com/go/compute v1.59.0


### PR DESCRIPTION
## Summary
- Bump Go to 1.26.2 in go.mod, ci.yml, and Dockerfile
- Apply `go fix ./...` changes