### PR TITLE
feat: support discovery across multiple GCP projects (BM-15117)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,4 @@
 /gpg.key
 
 .env
-.local
+/*.local

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /gpg.key
 
 .env
+.local

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## (next)
 
 - Bump Go to 1.26.2
+- feat: support discovery across multiple GCP projects via `STEADYBIT_EXTENSION_PROJECT_IDS` (shared credentials) or `STEADYBIT_EXTENSION_PROJECTS_ADVANCED` (per-project service-account impersonation). The legacy `STEADYBIT_EXTENSION_PROJECT_ID` continues to work.
 
 ## v1.0.22
 

--- a/README.md
+++ b/README.md
@@ -8,11 +8,16 @@ Learn about the capabilities of this extension in our [Reliability Hub](https://
 
 ## Configuration
 
-| Environment Variable                                   | Helm value                       | Meaning                                                                                                                                              | Required | Default                                        |
-|--------------------------------------------------------|----------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------|----------|------------------------------------------------|
-| `STEADYBIT_EXTENSION_CREDENTIALS_KEYFILE_PATH`         | gcp.credentialsKeyfilePath       | To authorize using a JSON key file via location path (https://cloud.google.com/iam/docs/managing-service-account-keys)                               | false    | Tries to get a client with default google apis |
-| `STEADYBIT_EXTENSION_PROJECT_ID`                       | gcp.projectID                    | The Google Cloud Project ID to be used                                                                                                               | true     |                                                |
-| `STEADYBIT_EXTENSION_DISCOVERY_ATTRIBUTES_EXCLUDES_VM` | discovery.attributes.excludes.vm | List of Target Attributes which will be excluded during discovery. Checked by key equality and supporting trailing "*"                               | false    |                                                |
+| Environment Variable                                   | Helm value                       | Meaning                                                                                                                                                                                               | Required | Default                                        |
+|--------------------------------------------------------|----------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------|------------------------------------------------|
+| `STEADYBIT_EXTENSION_CREDENTIALS_KEYFILE_PATH`         | gcp.credentialsKeyfilePath       | To authorize using a JSON key file via location path (https://cloud.google.com/iam/docs/managing-service-account-keys)                                                                                | false    | Tries to get a client with default google apis |
+| `STEADYBIT_EXTENSION_PROJECT_ID`                       | gcp.projectID                    | Legacy single-project configuration. Kept for backward compatibility. Mutually exclusive with `STEADYBIT_EXTENSION_PROJECT_IDS` and `STEADYBIT_EXTENSION_PROJECTS_ADVANCED`.                          | false    |                                                |
+| `STEADYBIT_EXTENSION_PROJECT_IDS`                      | gcp.projectIDs                   | Comma-separated list of GCP project IDs to discover. All projects are accessed with the same credentials (ADC or `CREDENTIALS_KEYFILE_PATH`).                                                         | false    |                                                |
+| `STEADYBIT_EXTENSION_PROJECTS_ADVANCED`                | gcp.projectsAdvanced             | JSON array configuring per-project service-account impersonation, e.g. `[{"projectId":"proj-a","impersonateServiceAccount":"sa@proj-a.iam.gserviceaccount.com"}]`.                                    | false    |                                                |
+| `STEADYBIT_EXTENSION_WORKER_THREADS`                   | gcp.workerThreads                | Number of goroutines used to fan discovery across configured projects.                                                                                                                                | false    | 1                                              |
+| `STEADYBIT_EXTENSION_DISCOVERY_ATTRIBUTES_EXCLUDES_VM` | discovery.attributes.excludes.vm | List of Target Attributes which will be excluded during discovery. Checked by key equality and supporting trailing "*"                                                                                | false    |                                                |
+
+Exactly one of `STEADYBIT_EXTENSION_PROJECT_ID`, `STEADYBIT_EXTENSION_PROJECT_IDS`, or `STEADYBIT_EXTENSION_PROJECTS_ADVANCED` must be set; setting more than one fails startup.
 
 The extension supports all environment variables provided by [steadybit/extension-kit](https://github.com/steadybit/extension-kit#environment-variables).
 
@@ -23,6 +28,36 @@ When installed as linux package this configuration is in`/etc/steadybit/extensio
 Provide the credentials to authorize the extension to access the Google Cloud API. The extension supports two ways to provide the credentials:
 Provide a JSON key file via the environment variable `STEADYBIT_EXTENSION_CREDENTIALS_KEYFILE_PATH` and mount it to the extension.
 Or create a secret with the key `credentialsKeyfileJson` and provide the json there.
+
+### Multi-project configuration
+
+The extension can discover resources across multiple GCP projects. Two modes are supported:
+
+#### Shared credentials (simple)
+
+List the projects in `STEADYBIT_EXTENSION_PROJECT_IDS` / `gcp.projectIDs`. The same identity (ADC or keyfile) is used to call every project, so that identity must hold the required permissions in each project.
+
+```
+--set gcp.projectIDs="proj-a,proj-b,proj-c"
+```
+
+#### Per-project service-account impersonation (advanced)
+
+Use `STEADYBIT_EXTENSION_PROJECTS_ADVANCED` / `gcp.projectsAdvanced` to define a dedicated service account per project. At runtime the extension's base identity exchanges tokens via the IAM Credentials API (`iam.serviceAccounts.getAccessToken`) to act as each target service account. This is the recommended pattern for environments that isolate permissions per project.
+
+```yaml
+gcp:
+  projectsAdvanced: |
+    [
+      {"projectId":"proj-a","impersonateServiceAccount":"extension@proj-a.iam.gserviceaccount.com"},
+      {"projectId":"proj-b","impersonateServiceAccount":"extension@proj-b.iam.gserviceaccount.com"}
+    ]
+```
+
+Prerequisites for impersonation:
+
+1. Each target project has a dedicated service account (e.g. `extension@proj-a.iam.gserviceaccount.com`) with the IAM roles it needs to perform the configured attacks.
+2. The identity the extension runs as (its base ADC or keyfile service account) has the `roles/iam.serviceAccountTokenCreator` role on every target service account. See [Service account impersonation](https://cloud.google.com/iam/docs/service-account-impersonation).
 
 ## Installation
 

--- a/charts/steadybit-extension-gcp/templates/deployment.yaml
+++ b/charts/steadybit-extension-gcp/templates/deployment.yaml
@@ -67,7 +67,19 @@ spec:
             {{- fail "breaking change: gcp.credentialsKeyfileJson is deprecated, use gcp.credentialsKeyfilePath instead or put credentialsKeyfileJson into a secret" }}
             {{- end }}
             - name: STEADYBIT_EXTENSION_PROJECT_ID
-              value: {{ .Values.gcp.projectID }}
+              value: {{ .Values.gcp.projectID | quote }}
+            {{- if .Values.gcp.projectIDs }}
+            - name: STEADYBIT_EXTENSION_PROJECT_IDS
+              value: {{ .Values.gcp.projectIDs | quote }}
+            {{- end }}
+            {{- if .Values.gcp.projectsAdvanced }}
+            - name: STEADYBIT_EXTENSION_PROJECTS_ADVANCED
+              value: {{ .Values.gcp.projectsAdvanced | quote }}
+            {{- end }}
+            {{- if .Values.gcp.workerThreads }}
+            - name: STEADYBIT_EXTENSION_WORKER_THREADS
+              value: {{ .Values.gcp.workerThreads | quote }}
+            {{- end }}
             {{- if .Values.discovery.attributes.excludes.vm }}
             - name: STEADYBIT_EXTENSION_DISCOVERY_ATTRIBUTES_EXCLUDES_VM
               value: {{ join "," .Values.discovery.attributes.excludes.vm | quote }}

--- a/charts/steadybit-extension-gcp/templates/deployment.yaml
+++ b/charts/steadybit-extension-gcp/templates/deployment.yaml
@@ -84,6 +84,10 @@ spec:
             - name: STEADYBIT_EXTENSION_DISCOVERY_ATTRIBUTES_EXCLUDES_VM
               value: {{ join "," .Values.discovery.attributes.excludes.vm | quote }}
             {{- end }}
+            {{- if .Values.testing.computeEndpoint }}
+            - name: STEADYBIT_EXTENSION_COMPUTE_ENDPOINT
+              value: {{ .Values.testing.computeEndpoint | quote }}
+            {{- end }}
             {{- include "extensionlib.deployment.env" (list .) | nindent 12 }}
             {{- with .Values.extraEnv }}
               {{- toYaml . | nindent 12 }}

--- a/charts/steadybit-extension-gcp/tests/__snapshot__/deployment_test.yaml.snap
+++ b/charts/steadybit-extension-gcp/tests/__snapshot__/deployment_test.yaml.snap
@@ -32,6 +32,8 @@ manifest should match snapshot using podAnnotations and Labels:
                   value: null
                 - name: STEADYBIT_EXTENSION_PROJECT_ID
                   value: some-project-id
+                - name: STEADYBIT_EXTENSION_WORKER_THREADS
+                  value: "1"
                 - name: STEADYBIT_LOG_LEVEL
                   value: INFO
                 - name: STEADYBIT_LOG_FORMAT
@@ -108,7 +110,9 @@ manifest should match snapshot with TLS:
                 - name: STEADYBIT_EXTENSION_CREDENTIALS_KEYFILE_PATH
                   value: null
                 - name: STEADYBIT_EXTENSION_PROJECT_ID
-                  value: null
+                  value: ""
+                - name: STEADYBIT_EXTENSION_WORKER_THREADS
+                  value: "1"
                 - name: STEADYBIT_LOG_LEVEL
                   value: INFO
                 - name: STEADYBIT_LOG_FORMAT
@@ -165,6 +169,87 @@ manifest should match snapshot with TLS:
               secret:
                 optional: false
                 secretName: server-cert
+manifest should match snapshot with advanced projects impersonation:
+  1: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      labels:
+        steadybit.com/discovery-disabled: "true"
+        steadybit.com/extension: "true"
+      name: RELEASE-NAME-steadybit-extension-gcp
+      namespace: NAMESPACE
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app.kubernetes.io/instance: RELEASE-NAME
+          app.kubernetes.io/name: steadybit-extension-gcp
+      template:
+        metadata:
+          annotations:
+            oneagent.dynatrace.com/injection: "false"
+          labels:
+            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/name: steadybit-extension-gcp
+            steadybit.com/discovery-disabled: "true"
+            steadybit.com/extension: "true"
+        spec:
+          containers:
+            - env:
+                - name: STEADYBIT_EXTENSION_CREDENTIALS_KEYFILE_PATH
+                  value: null
+                - name: STEADYBIT_EXTENSION_PROJECT_ID
+                  value: ""
+                - name: STEADYBIT_EXTENSION_PROJECTS_ADVANCED
+                  value: '[{"projectId":"proj-a","impersonateServiceAccount":"sa@proj-a.iam.gserviceaccount.com"}]'
+                - name: STEADYBIT_EXTENSION_WORKER_THREADS
+                  value: "1"
+                - name: STEADYBIT_LOG_LEVEL
+                  value: INFO
+                - name: STEADYBIT_LOG_FORMAT
+                  value: text
+              image: ghcr.io/steadybit/extension-gcp:v0.0.0
+              imagePullPolicy: IfNotPresent
+              livenessProbe:
+                failureThreshold: 5
+                httpGet:
+                  path: /health/liveness
+                  port: 8081
+                initialDelaySeconds: 10
+                periodSeconds: 10
+                successThreshold: 1
+                timeoutSeconds: 5
+              name: extension
+              readinessProbe:
+                failureThreshold: 3
+                httpGet:
+                  path: /health/readiness
+                  port: 8081
+                initialDelaySeconds: 10
+                periodSeconds: 10
+                successThreshold: 1
+                timeoutSeconds: 1
+              resources:
+                limits:
+                  cpu: 200m
+                  memory: 48Mi
+                requests:
+                  cpu: 50m
+                  memory: 24Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                readOnlyRootFilesystem: true
+              volumeMounts: null
+          securityContext:
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+          serviceAccountName: steadybit-extension-gcp
+          volumes: null
 manifest should match snapshot with credentials secret path:
   1: |
     apiVersion: apps/v1
@@ -197,6 +282,8 @@ manifest should match snapshot with credentials secret path:
                   value: /etc/gcp/secret/credentials.json
                 - name: STEADYBIT_EXTENSION_PROJECT_ID
                   value: some-project-id
+                - name: STEADYBIT_EXTENSION_WORKER_THREADS
+                  value: "1"
                 - name: STEADYBIT_LOG_LEVEL
                   value: INFO
                 - name: STEADYBIT_LOG_FORMAT
@@ -282,7 +369,9 @@ manifest should match snapshot with custom image registry:
                 - name: STEADYBIT_EXTENSION_CREDENTIALS_KEYFILE_PATH
                   value: null
                 - name: STEADYBIT_EXTENSION_PROJECT_ID
-                  value: null
+                  value: ""
+                - name: STEADYBIT_EXTENSION_WORKER_THREADS
+                  value: "1"
                 - name: STEADYBIT_LOG_LEVEL
                   value: INFO
                 - name: STEADYBIT_LOG_FORMAT
@@ -359,7 +448,9 @@ manifest should match snapshot with extra env vars:
                 - name: STEADYBIT_EXTENSION_CREDENTIALS_KEYFILE_PATH
                   value: null
                 - name: STEADYBIT_EXTENSION_PROJECT_ID
-                  value: null
+                  value: ""
+                - name: STEADYBIT_EXTENSION_WORKER_THREADS
+                  value: "1"
                 - name: STEADYBIT_LOG_LEVEL
                   value: INFO
                 - name: STEADYBIT_LOG_FORMAT
@@ -445,7 +536,9 @@ manifest should match snapshot with extra labels:
                 - name: STEADYBIT_EXTENSION_CREDENTIALS_KEYFILE_PATH
                   value: null
                 - name: STEADYBIT_EXTENSION_PROJECT_ID
-                  value: null
+                  value: ""
+                - name: STEADYBIT_EXTENSION_WORKER_THREADS
+                  value: "1"
                 - name: STEADYBIT_LOG_LEVEL
                   value: INFO
                 - name: STEADYBIT_LOG_FORMAT
@@ -522,7 +615,9 @@ manifest should match snapshot with global image pull secrets:
                 - name: STEADYBIT_EXTENSION_CREDENTIALS_KEYFILE_PATH
                   value: null
                 - name: STEADYBIT_EXTENSION_PROJECT_ID
-                  value: null
+                  value: ""
+                - name: STEADYBIT_EXTENSION_WORKER_THREADS
+                  value: "1"
                 - name: STEADYBIT_LOG_LEVEL
                   value: INFO
                 - name: STEADYBIT_LOG_FORMAT
@@ -601,7 +696,9 @@ manifest should match snapshot with global image registry:
                 - name: STEADYBIT_EXTENSION_CREDENTIALS_KEYFILE_PATH
                   value: null
                 - name: STEADYBIT_EXTENSION_PROJECT_ID
-                  value: null
+                  value: ""
+                - name: STEADYBIT_EXTENSION_WORKER_THREADS
+                  value: "1"
                 - name: STEADYBIT_LOG_LEVEL
                   value: INFO
                 - name: STEADYBIT_LOG_FORMAT
@@ -678,7 +775,9 @@ manifest should match snapshot with global priority class:
                 - name: STEADYBIT_EXTENSION_CREDENTIALS_KEYFILE_PATH
                   value: null
                 - name: STEADYBIT_EXTENSION_PROJECT_ID
-                  value: null
+                  value: ""
+                - name: STEADYBIT_EXTENSION_WORKER_THREADS
+                  value: "1"
                 - name: STEADYBIT_LOG_LEVEL
                   value: INFO
                 - name: STEADYBIT_LOG_FORMAT
@@ -756,7 +855,9 @@ manifest should match snapshot with image pull secrets:
                 - name: STEADYBIT_EXTENSION_CREDENTIALS_KEYFILE_PATH
                   value: null
                 - name: STEADYBIT_EXTENSION_PROJECT_ID
-                  value: null
+                  value: ""
+                - name: STEADYBIT_EXTENSION_WORKER_THREADS
+                  value: "1"
                 - name: STEADYBIT_LOG_LEVEL
                   value: INFO
                 - name: STEADYBIT_LOG_FORMAT
@@ -835,7 +936,90 @@ manifest should match snapshot with legacy image name containing registry:
                 - name: STEADYBIT_EXTENSION_CREDENTIALS_KEYFILE_PATH
                   value: null
                 - name: STEADYBIT_EXTENSION_PROJECT_ID
+                  value: ""
+                - name: STEADYBIT_EXTENSION_WORKER_THREADS
+                  value: "1"
+                - name: STEADYBIT_LOG_LEVEL
+                  value: INFO
+                - name: STEADYBIT_LOG_FORMAT
+                  value: text
+              image: ghcr.io/steadybit/extension-gcp:v0.0.0
+              imagePullPolicy: IfNotPresent
+              livenessProbe:
+                failureThreshold: 5
+                httpGet:
+                  path: /health/liveness
+                  port: 8081
+                initialDelaySeconds: 10
+                periodSeconds: 10
+                successThreshold: 1
+                timeoutSeconds: 5
+              name: extension
+              readinessProbe:
+                failureThreshold: 3
+                httpGet:
+                  path: /health/readiness
+                  port: 8081
+                initialDelaySeconds: 10
+                periodSeconds: 10
+                successThreshold: 1
+                timeoutSeconds: 1
+              resources:
+                limits:
+                  cpu: 200m
+                  memory: 48Mi
+                requests:
+                  cpu: 50m
+                  memory: 24Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                readOnlyRootFilesystem: true
+              volumeMounts: null
+          securityContext:
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+          serviceAccountName: steadybit-extension-gcp
+          volumes: null
+manifest should match snapshot with multiple project IDs:
+  1: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      labels:
+        steadybit.com/discovery-disabled: "true"
+        steadybit.com/extension: "true"
+      name: RELEASE-NAME-steadybit-extension-gcp
+      namespace: NAMESPACE
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app.kubernetes.io/instance: RELEASE-NAME
+          app.kubernetes.io/name: steadybit-extension-gcp
+      template:
+        metadata:
+          annotations:
+            oneagent.dynatrace.com/injection: "false"
+          labels:
+            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/name: steadybit-extension-gcp
+            steadybit.com/discovery-disabled: "true"
+            steadybit.com/extension: "true"
+        spec:
+          containers:
+            - env:
+                - name: STEADYBIT_EXTENSION_CREDENTIALS_KEYFILE_PATH
                   value: null
+                - name: STEADYBIT_EXTENSION_PROJECT_ID
+                  value: ""
+                - name: STEADYBIT_EXTENSION_PROJECT_IDS
+                  value: proj-a,proj-b
+                - name: STEADYBIT_EXTENSION_WORKER_THREADS
+                  value: "3"
                 - name: STEADYBIT_LOG_LEVEL
                   value: INFO
                 - name: STEADYBIT_LOG_FORMAT
@@ -913,6 +1097,8 @@ manifest should match snapshot with mutual TLS:
                   value: null
                 - name: STEADYBIT_EXTENSION_PROJECT_ID
                   value: some-project-id
+                - name: STEADYBIT_EXTENSION_WORKER_THREADS
+                  value: "1"
                 - name: STEADYBIT_LOG_LEVEL
                   value: INFO
                 - name: STEADYBIT_LOG_FORMAT
@@ -1009,7 +1195,9 @@ manifest should match snapshot with mutual TLS using containerPaths:
                 - name: STEADYBIT_EXTENSION_CREDENTIALS_KEYFILE_PATH
                   value: null
                 - name: STEADYBIT_EXTENSION_PROJECT_ID
-                  value: null
+                  value: ""
+                - name: STEADYBIT_EXTENSION_WORKER_THREADS
+                  value: "1"
                 - name: STEADYBIT_LOG_LEVEL
                   value: INFO
                 - name: STEADYBIT_LOG_FORMAT
@@ -1092,7 +1280,9 @@ manifest should match snapshot with podSecurityContext:
                 - name: STEADYBIT_EXTENSION_CREDENTIALS_KEYFILE_PATH
                   value: null
                 - name: STEADYBIT_EXTENSION_PROJECT_ID
-                  value: null
+                  value: ""
+                - name: STEADYBIT_EXTENSION_WORKER_THREADS
+                  value: "1"
                 - name: STEADYBIT_LOG_LEVEL
                   value: INFO
                 - name: STEADYBIT_LOG_FORMAT
@@ -1170,7 +1360,9 @@ manifest should match snapshot with priority class:
                 - name: STEADYBIT_EXTENSION_CREDENTIALS_KEYFILE_PATH
                   value: null
                 - name: STEADYBIT_EXTENSION_PROJECT_ID
-                  value: null
+                  value: ""
+                - name: STEADYBIT_EXTENSION_WORKER_THREADS
+                  value: "1"
                 - name: STEADYBIT_LOG_LEVEL
                   value: INFO
                 - name: STEADYBIT_LOG_FORMAT
@@ -1248,7 +1440,9 @@ manifest should match snapshot without TLS:
                 - name: STEADYBIT_EXTENSION_CREDENTIALS_KEYFILE_PATH
                   value: null
                 - name: STEADYBIT_EXTENSION_PROJECT_ID
-                  value: null
+                  value: ""
+                - name: STEADYBIT_EXTENSION_WORKER_THREADS
+                  value: "1"
                 - name: STEADYBIT_LOG_LEVEL
                   value: INFO
                 - name: STEADYBIT_LOG_FORMAT

--- a/charts/steadybit-extension-gcp/tests/__snapshot__/deployment_test.yaml.snap
+++ b/charts/steadybit-extension-gcp/tests/__snapshot__/deployment_test.yaml.snap
@@ -1409,6 +1409,87 @@ manifest should match snapshot with priority class:
               type: RuntimeDefault
           serviceAccountName: steadybit-extension-gcp
           volumes: null
+manifest should match snapshot with testing compute endpoint:
+  1: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      labels:
+        steadybit.com/discovery-disabled: "true"
+        steadybit.com/extension: "true"
+      name: RELEASE-NAME-steadybit-extension-gcp
+      namespace: NAMESPACE
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app.kubernetes.io/instance: RELEASE-NAME
+          app.kubernetes.io/name: steadybit-extension-gcp
+      template:
+        metadata:
+          annotations:
+            oneagent.dynatrace.com/injection: "false"
+          labels:
+            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/name: steadybit-extension-gcp
+            steadybit.com/discovery-disabled: "true"
+            steadybit.com/extension: "true"
+        spec:
+          containers:
+            - env:
+                - name: STEADYBIT_EXTENSION_CREDENTIALS_KEYFILE_PATH
+                  value: null
+                - name: STEADYBIT_EXTENSION_PROJECT_ID
+                  value: mock-project
+                - name: STEADYBIT_EXTENSION_WORKER_THREADS
+                  value: "1"
+                - name: STEADYBIT_EXTENSION_COMPUTE_ENDPOINT
+                  value: http://host.minikube.internal:12345
+                - name: STEADYBIT_LOG_LEVEL
+                  value: INFO
+                - name: STEADYBIT_LOG_FORMAT
+                  value: text
+              image: ghcr.io/steadybit/extension-gcp:v0.0.0
+              imagePullPolicy: IfNotPresent
+              livenessProbe:
+                failureThreshold: 5
+                httpGet:
+                  path: /health/liveness
+                  port: 8081
+                initialDelaySeconds: 10
+                periodSeconds: 10
+                successThreshold: 1
+                timeoutSeconds: 5
+              name: extension
+              readinessProbe:
+                failureThreshold: 3
+                httpGet:
+                  path: /health/readiness
+                  port: 8081
+                initialDelaySeconds: 10
+                periodSeconds: 10
+                successThreshold: 1
+                timeoutSeconds: 1
+              resources:
+                limits:
+                  cpu: 200m
+                  memory: 48Mi
+                requests:
+                  cpu: 50m
+                  memory: 24Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                readOnlyRootFilesystem: true
+              volumeMounts: null
+          securityContext:
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+          serviceAccountName: steadybit-extension-gcp
+          volumes: null
 manifest should match snapshot without TLS:
   1: |
     apiVersion: apps/v1

--- a/charts/steadybit-extension-gcp/tests/deployment_test.yaml
+++ b/charts/steadybit-extension-gcp/tests/deployment_test.yaml
@@ -161,3 +161,12 @@ tests:
         projectsAdvanced: '[{"projectId":"proj-a","impersonateServiceAccount":"sa@proj-a.iam.gserviceaccount.com"}]'
     asserts:
       - matchSnapshot: {}
+
+  - it: manifest should match snapshot with testing compute endpoint
+    set:
+      gcp:
+        projectID: mock-project
+      testing:
+        computeEndpoint: http://host.minikube.internal:12345
+    asserts:
+      - matchSnapshot: {}

--- a/charts/steadybit-extension-gcp/tests/deployment_test.yaml
+++ b/charts/steadybit-extension-gcp/tests/deployment_test.yaml
@@ -146,3 +146,18 @@ tests:
             - global-pull-secret
     asserts:
       - matchSnapshot: {}
+
+  - it: manifest should match snapshot with multiple project IDs
+    set:
+      gcp:
+        projectIDs: "proj-a,proj-b"
+        workerThreads: 3
+    asserts:
+      - matchSnapshot: {}
+
+  - it: manifest should match snapshot with advanced projects impersonation
+    set:
+      gcp:
+        projectsAdvanced: '[{"projectId":"proj-a","impersonateServiceAccount":"sa@proj-a.iam.gserviceaccount.com"}]'
+    asserts:
+      - matchSnapshot: {}

--- a/charts/steadybit-extension-gcp/values.yaml
+++ b/charts/steadybit-extension-gcp/values.yaml
@@ -136,7 +136,14 @@ extraEnvFrom: []
 
 gcp:
   credentialsKeyfilePath: ""
+  # gcp.projectID -- Legacy single-project configuration. Kept for backward compatibility. Do not set together with projectIDs or projectsAdvanced.
   projectID: ""
+  # gcp.projectIDs -- Comma-separated list of GCP project IDs to discover when using a single credential across all projects. Example: "proj-a,proj-b".
+  projectIDs: ""
+  # gcp.projectsAdvanced -- JSON array enabling per-project service-account impersonation. Example: '[{"projectId":"proj-a","impersonateServiceAccount":"sa@proj-a.iam.gserviceaccount.com"}]'.
+  projectsAdvanced: ""
+  # gcp.workerThreads -- Number of goroutines used to fan discovery across configured projects.
+  workerThreads: 1
   # gcp.existingSecret -- If defined, will skip secret creation and instead assume that the referenced secret contains the key credentialsKeyfileJson
   existingSecret: null
 

--- a/charts/steadybit-extension-gcp/values.yaml
+++ b/charts/steadybit-extension-gcp/values.yaml
@@ -153,3 +153,8 @@ discovery:
     excludes:
       # discovery.attributes.excludes.vm -- List of attributes to exclude from VM discovery.
       vm: []
+
+# testing -- Overrides intended for e2e tests only. Setting computeEndpoint causes the extension
+# to skip GCP authentication and must not be used in production deployments.
+testing:
+  computeEndpoint: ""

--- a/config/config.go
+++ b/config/config.go
@@ -20,9 +20,9 @@ type Specification struct {
 	//STEADYBIT_EXTENSION_CREDENTIALS_KEYFILE_PATH
 	CredentialsKeyfilePath string `json:"credentialsKeyfilePath" required:"false" split_words:"true"`
 	//STEADYBIT_EXTENSION_PROJECT_ID - legacy single-project config, kept for backward compatibility.
-	ProjectID string `json:"projectId" required:"false" split_words:"true"`
+	ProjectId string `json:"projectId" required:"false" split_words:"true"`
 	//STEADYBIT_EXTENSION_PROJECT_IDS - comma-separated list of GCP project IDs to discover. Uses the same credentials for all projects.
-	ProjectIDs []string `json:"projectIds" required:"false" split_words:"true"`
+	ProjectIds []string `json:"projectIds" required:"false" split_words:"true"`
 	//STEADYBIT_EXTENSION_PROJECTS_ADVANCED - JSON array of {projectId, impersonateServiceAccount}. Enables per-project service-account impersonation.
 	ProjectsAdvanced ProjectsAdvanced `json:"projectsAdvanced" required:"false" split_words:"true"`
 	//STEADYBIT_EXTENSION_WORKER_THREADS - number of goroutines used to fan out discovery across projects.
@@ -58,8 +58,8 @@ func ParseConfiguration() {
 		log.Fatal().Err(err).Msgf("Failed to parse configuration from environment.")
 	}
 
-	Config.ProjectID = strings.TrimSpace(Config.ProjectID)
-	Config.ProjectIDs = trimAndFilter(Config.ProjectIDs)
+	Config.ProjectId = strings.TrimSpace(Config.ProjectId)
+	Config.ProjectIds = trimAndFilter(Config.ProjectIds)
 }
 
 func ValidateConfiguration() {
@@ -75,9 +75,9 @@ func ResolvedProjects() []ProjectAdvanced {
 	if len(Config.ProjectsAdvanced) > 0 {
 		return Config.ProjectsAdvanced
 	}
-	ids := Config.ProjectIDs
-	if len(ids) == 0 && Config.ProjectID != "" {
-		ids = []string{Config.ProjectID}
+	ids := Config.ProjectIds
+	if len(ids) == 0 && Config.ProjectId != "" {
+		ids = []string{Config.ProjectId}
 	}
 	projects := make([]ProjectAdvanced, 0, len(ids))
 	for _, id := range ids {
@@ -88,10 +88,10 @@ func ResolvedProjects() []ProjectAdvanced {
 
 func validateProjects(c *Specification) error {
 	sources := 0
-	if c.ProjectID != "" {
+	if c.ProjectId != "" {
 		sources++
 	}
-	if len(c.ProjectIDs) > 0 {
+	if len(c.ProjectIds) > 0 {
 		sources++
 	}
 	if len(c.ProjectsAdvanced) > 0 {
@@ -103,7 +103,7 @@ func validateProjects(c *Specification) error {
 	if sources > 1 {
 		return fmt.Errorf("only one of STEADYBIT_EXTENSION_PROJECT_ID, STEADYBIT_EXTENSION_PROJECT_IDS, STEADYBIT_EXTENSION_PROJECTS_ADVANCED may be set")
 	}
-	if err := checkDuplicateIDs("STEADYBIT_EXTENSION_PROJECT_IDS", c.ProjectIDs); err != nil {
+	if err := checkDuplicateIDs("STEADYBIT_EXTENSION_PROJECT_IDS", c.ProjectIds); err != nil {
 		return err
 	}
 	seen := make(map[string]struct{})

--- a/config/config.go
+++ b/config/config.go
@@ -5,6 +5,10 @@
 package config
 
 import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
 	"github.com/kelseyhightower/envconfig"
 	"github.com/rs/zerolog/log"
 )
@@ -15,10 +19,31 @@ import (
 type Specification struct {
 	//STEADYBIT_EXTENSION_CREDENTIALS_KEYFILE_PATH
 	CredentialsKeyfilePath string `json:"credentialsKeyfilePath" required:"false" split_words:"true"`
-	//STEADYBIT_EXTENSION_PROJECT_ID
-	ProjectID                     string   `json:"projectId" required:"false" split_words:"true"`
+	//STEADYBIT_EXTENSION_PROJECT_ID - legacy single-project config, kept for backward compatibility.
+	ProjectID string `json:"projectId" required:"false" split_words:"true"`
+	//STEADYBIT_EXTENSION_PROJECT_IDS - comma-separated list of GCP project IDs to discover. Uses the same credentials for all projects.
+	ProjectIDs []string `json:"projectIds" required:"false" split_words:"true"`
+	//STEADYBIT_EXTENSION_PROJECTS_ADVANCED - JSON array of {projectId, impersonateServiceAccount}. Enables per-project service-account impersonation.
+	ProjectsAdvanced ProjectsAdvanced `json:"projectsAdvanced" required:"false" split_words:"true"`
+	//STEADYBIT_EXTENSION_WORKER_THREADS - number of goroutines used to fan out discovery across projects.
+	WorkerThreads                 int      `json:"workerThreads" required:"false" split_words:"true" default:"1"`
 	DiscoveryAttributesExcludesVM []string `json:"discoveryAttributesExcludesVM" required:"false" split_words:"true"`
 	EnrichVMDataForTargetTypes    []string `json:"EnrichVMDataForTargetTypes" split_words:"true" default:"com.steadybit.extension_jvm.jvm-instance,com.steadybit.extension_kubernetes.argo-rollout,com.steadybit.extension_kubernetes.kubernetes-deployment,com.steadybit.extension_kubernetes.kubernetes-pod,com.steadybit.extension_kubernetes.kubernetes-daemonset,com.steadybit.extension_kubernetes.kubernetes-statefulset,com.steadybit.extension_http.client-location,com.steadybit.extension_jmeter.location,com.steadybit.extension_k6.location,com.steadybit.extension_gatling.location"`
+}
+
+type ProjectAdvanced struct {
+	ProjectID                 string `json:"projectId"`
+	ImpersonateServiceAccount string `json:"impersonateServiceAccount"`
+}
+
+type ProjectsAdvanced []ProjectAdvanced
+
+func (p *ProjectsAdvanced) UnmarshalText(text []byte) error {
+	if len(text) == 0 || string(text) == "[]" {
+		*p = ProjectsAdvanced{}
+		return nil
+	}
+	return json.Unmarshal(text, (*[]ProjectAdvanced)(p))
 }
 
 var (
@@ -30,8 +55,85 @@ func ParseConfiguration() {
 	if err != nil {
 		log.Fatal().Err(err).Msgf("Failed to parse configuration from environment.")
 	}
+
+	Config.ProjectID = strings.TrimSpace(Config.ProjectID)
+	Config.ProjectIDs = trimAndFilter(Config.ProjectIDs)
 }
 
 func ValidateConfiguration() {
-	// You may optionally validate the configuration here.
+	if err := validateProjects(&Config); err != nil {
+		log.Fatal().Err(err).Msg("Invalid GCP project configuration.")
+	}
+	log.Info().Msgf("Configured %d GCP project(s) for discovery.", len(ResolvedProjects()))
+}
+
+// ResolvedProjects returns the effective list of projects derived from ProjectID, ProjectIDs and ProjectsAdvanced.
+// It assumes ValidateConfiguration has been called and the mutual-exclusion rules have been enforced.
+func ResolvedProjects() []ProjectAdvanced {
+	if len(Config.ProjectsAdvanced) > 0 {
+		return Config.ProjectsAdvanced
+	}
+	ids := Config.ProjectIDs
+	if len(ids) == 0 && Config.ProjectID != "" {
+		ids = []string{Config.ProjectID}
+	}
+	projects := make([]ProjectAdvanced, 0, len(ids))
+	for _, id := range ids {
+		projects = append(projects, ProjectAdvanced{ProjectID: id})
+	}
+	return projects
+}
+
+func validateProjects(c *Specification) error {
+	sources := 0
+	if c.ProjectID != "" {
+		sources++
+	}
+	if len(c.ProjectIDs) > 0 {
+		sources++
+	}
+	if len(c.ProjectsAdvanced) > 0 {
+		sources++
+	}
+	if sources == 0 {
+		return fmt.Errorf("no GCP project configured: set STEADYBIT_EXTENSION_PROJECT_IDS or STEADYBIT_EXTENSION_PROJECTS_ADVANCED")
+	}
+	if sources > 1 {
+		return fmt.Errorf("only one of STEADYBIT_EXTENSION_PROJECT_ID, STEADYBIT_EXTENSION_PROJECT_IDS, STEADYBIT_EXTENSION_PROJECTS_ADVANCED may be set")
+	}
+	if err := checkDuplicateIDs("STEADYBIT_EXTENSION_PROJECT_IDS", c.ProjectIDs); err != nil {
+		return err
+	}
+	seen := make(map[string]struct{})
+	for _, p := range c.ProjectsAdvanced {
+		if strings.TrimSpace(p.ProjectID) == "" {
+			return fmt.Errorf("STEADYBIT_EXTENSION_PROJECTS_ADVANCED: every entry must have a non-empty projectId")
+		}
+		if _, dup := seen[p.ProjectID]; dup {
+			return fmt.Errorf("STEADYBIT_EXTENSION_PROJECTS_ADVANCED: duplicate projectId '%s'", p.ProjectID)
+		}
+		seen[p.ProjectID] = struct{}{}
+	}
+	return nil
+}
+
+func checkDuplicateIDs(source string, ids []string) error {
+	seen := make(map[string]struct{}, len(ids))
+	for _, id := range ids {
+		if _, dup := seen[id]; dup {
+			return fmt.Errorf("%s: duplicate projectId '%s'", source, id)
+		}
+		seen[id] = struct{}{}
+	}
+	return nil
+}
+
+func trimAndFilter(values []string) []string {
+	out := make([]string, 0, len(values))
+	for _, v := range values {
+		if trimmed := strings.TrimSpace(v); trimmed != "" {
+			out = append(out, trimmed)
+		}
+	}
+	return out
 }

--- a/config/config.go
+++ b/config/config.go
@@ -26,7 +26,9 @@ type Specification struct {
 	//STEADYBIT_EXTENSION_PROJECTS_ADVANCED - JSON array of {projectId, impersonateServiceAccount}. Enables per-project service-account impersonation.
 	ProjectsAdvanced ProjectsAdvanced `json:"projectsAdvanced" required:"false" split_words:"true"`
 	//STEADYBIT_EXTENSION_WORKER_THREADS - number of goroutines used to fan out discovery across projects.
-	WorkerThreads                 int      `json:"workerThreads" required:"false" split_words:"true" default:"1"`
+	WorkerThreads int `json:"workerThreads" required:"false" split_words:"true" default:"1"`
+	//STEADYBIT_EXTENSION_COMPUTE_ENDPOINT - override the Compute API endpoint. Intended for testing only; when set the client skips authentication.
+	ComputeEndpoint               string   `json:"computeEndpoint" required:"false" split_words:"true"`
 	DiscoveryAttributesExcludesVM []string `json:"discoveryAttributesExcludesVM" required:"false" split_words:"true"`
 	EnrichVMDataForTargetTypes    []string `json:"EnrichVMDataForTargetTypes" split_words:"true" default:"com.steadybit.extension_jvm.jvm-instance,com.steadybit.extension_kubernetes.argo-rollout,com.steadybit.extension_kubernetes.kubernetes-deployment,com.steadybit.extension_kubernetes.kubernetes-pod,com.steadybit.extension_kubernetes.kubernetes-daemonset,com.steadybit.extension_kubernetes.kubernetes-statefulset,com.steadybit.extension_http.client-location,com.steadybit.extension_jmeter.location,com.steadybit.extension_k6.location,com.steadybit.extension_gatling.location"`
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -12,12 +12,12 @@ import (
 )
 
 func TestValidateProjects_LegacySingleProjectAccepted(t *testing.T) {
-	spec := &Specification{ProjectID: "proj-a"}
+	spec := &Specification{ProjectId: "proj-a"}
 	require.NoError(t, validateProjects(spec))
 }
 
 func TestValidateProjects_PluralListAccepted(t *testing.T) {
-	spec := &Specification{ProjectIDs: []string{"proj-a", "proj-b"}}
+	spec := &Specification{ProjectIds: []string{"proj-a", "proj-b"}}
 	require.NoError(t, validateProjects(spec))
 }
 
@@ -36,7 +36,7 @@ func TestValidateProjects_NoSourceRejected(t *testing.T) {
 }
 
 func TestValidateProjects_LegacyAndPluralRejected(t *testing.T) {
-	spec := &Specification{ProjectID: "proj-a", ProjectIDs: []string{"proj-b"}}
+	spec := &Specification{ProjectId: "proj-a", ProjectIds: []string{"proj-b"}}
 	err := validateProjects(spec)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "only one of")
@@ -44,7 +44,7 @@ func TestValidateProjects_LegacyAndPluralRejected(t *testing.T) {
 
 func TestValidateProjects_PluralAndAdvancedRejected(t *testing.T) {
 	spec := &Specification{
-		ProjectIDs:       []string{"proj-a"},
+		ProjectIds:       []string{"proj-a"},
 		ProjectsAdvanced: ProjectsAdvanced{{ProjectID: "proj-b"}},
 	}
 	err := validateProjects(spec)
@@ -54,7 +54,7 @@ func TestValidateProjects_PluralAndAdvancedRejected(t *testing.T) {
 
 func TestValidateProjects_LegacyAndAdvancedRejected(t *testing.T) {
 	spec := &Specification{
-		ProjectID:        "proj-a",
+		ProjectId:        "proj-a",
 		ProjectsAdvanced: ProjectsAdvanced{{ProjectID: "proj-b"}},
 	}
 	err := validateProjects(spec)
@@ -63,7 +63,7 @@ func TestValidateProjects_LegacyAndAdvancedRejected(t *testing.T) {
 }
 
 func TestValidateProjects_PluralDuplicateProjectRejected(t *testing.T) {
-	spec := &Specification{ProjectIDs: []string{"proj-a", "proj-a"}}
+	spec := &Specification{ProjectIds: []string{"proj-a", "proj-a"}}
 	err := validateProjects(spec)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "duplicate projectId 'proj-a'")
@@ -107,7 +107,7 @@ func TestResolvedProjects_PrefersAdvanced(t *testing.T) {
 	t.Cleanup(func() { Config = original })
 
 	Config = Specification{
-		ProjectIDs:       []string{"plural-a"},
+		ProjectIds:       []string{"plural-a"},
 		ProjectsAdvanced: ProjectsAdvanced{{ProjectID: "adv-a"}},
 	}
 	resolved := ResolvedProjects()
@@ -119,7 +119,7 @@ func TestResolvedProjects_FallsBackToLegacy(t *testing.T) {
 	original := Config
 	t.Cleanup(func() { Config = original })
 
-	Config = Specification{ProjectID: "legacy-a"}
+	Config = Specification{ProjectId: "legacy-a"}
 	resolved := ResolvedProjects()
 	require.Len(t, resolved, 1)
 	assert.Equal(t, "legacy-a", resolved[0].ProjectID)
@@ -130,7 +130,7 @@ func TestResolvedProjects_UsesPlural(t *testing.T) {
 	original := Config
 	t.Cleanup(func() { Config = original })
 
-	Config = Specification{ProjectIDs: []string{"plural-a", "plural-b"}}
+	Config = Specification{ProjectIds: []string{"plural-a", "plural-b"}}
 	resolved := ResolvedProjects()
 	require.Len(t, resolved, 2)
 	assert.Equal(t, "plural-a", resolved[0].ProjectID)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2026 steadybit GmbH. All rights reserved.
+ */
+
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateProjects_LegacySingleProjectAccepted(t *testing.T) {
+	spec := &Specification{ProjectID: "proj-a"}
+	require.NoError(t, validateProjects(spec))
+}
+
+func TestValidateProjects_PluralListAccepted(t *testing.T) {
+	spec := &Specification{ProjectIDs: []string{"proj-a", "proj-b"}}
+	require.NoError(t, validateProjects(spec))
+}
+
+func TestValidateProjects_AdvancedAccepted(t *testing.T) {
+	spec := &Specification{ProjectsAdvanced: ProjectsAdvanced{
+		{ProjectID: "proj-a", ImpersonateServiceAccount: "sa@proj-a.iam.gserviceaccount.com"},
+	}}
+	require.NoError(t, validateProjects(spec))
+}
+
+func TestValidateProjects_NoSourceRejected(t *testing.T) {
+	spec := &Specification{}
+	err := validateProjects(spec)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no GCP project configured")
+}
+
+func TestValidateProjects_LegacyAndPluralRejected(t *testing.T) {
+	spec := &Specification{ProjectID: "proj-a", ProjectIDs: []string{"proj-b"}}
+	err := validateProjects(spec)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "only one of")
+}
+
+func TestValidateProjects_PluralAndAdvancedRejected(t *testing.T) {
+	spec := &Specification{
+		ProjectIDs:       []string{"proj-a"},
+		ProjectsAdvanced: ProjectsAdvanced{{ProjectID: "proj-b"}},
+	}
+	err := validateProjects(spec)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "only one of")
+}
+
+func TestValidateProjects_LegacyAndAdvancedRejected(t *testing.T) {
+	spec := &Specification{
+		ProjectID:        "proj-a",
+		ProjectsAdvanced: ProjectsAdvanced{{ProjectID: "proj-b"}},
+	}
+	err := validateProjects(spec)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "only one of")
+}
+
+func TestValidateProjects_PluralDuplicateProjectRejected(t *testing.T) {
+	spec := &Specification{ProjectIDs: []string{"proj-a", "proj-a"}}
+	err := validateProjects(spec)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "duplicate projectId 'proj-a'")
+}
+
+func TestValidateProjects_AdvancedDuplicateProjectRejected(t *testing.T) {
+	spec := &Specification{ProjectsAdvanced: ProjectsAdvanced{
+		{ProjectID: "proj-a"},
+		{ProjectID: "proj-a", ImpersonateServiceAccount: "sa@..."},
+	}}
+	err := validateProjects(spec)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "duplicate projectId 'proj-a'")
+}
+
+func TestValidateProjects_AdvancedEmptyProjectIdRejected(t *testing.T) {
+	spec := &Specification{ProjectsAdvanced: ProjectsAdvanced{
+		{ProjectID: "", ImpersonateServiceAccount: "sa@..."},
+	}}
+	err := validateProjects(spec)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "non-empty projectId")
+}
+
+func TestProjectsAdvancedUnmarshalText_EmptyReturnsEmpty(t *testing.T) {
+	var p ProjectsAdvanced
+	require.NoError(t, p.UnmarshalText(nil))
+	assert.Empty(t, p)
+}
+
+func TestProjectsAdvancedUnmarshalText_Json(t *testing.T) {
+	var p ProjectsAdvanced
+	require.NoError(t, p.UnmarshalText([]byte(`[{"projectId":"proj-a","impersonateServiceAccount":"sa@proj-a.iam.gserviceaccount.com"}]`)))
+	require.Len(t, p, 1)
+	assert.Equal(t, "proj-a", p[0].ProjectID)
+	assert.Equal(t, "sa@proj-a.iam.gserviceaccount.com", p[0].ImpersonateServiceAccount)
+}
+
+func TestResolvedProjects_PrefersAdvanced(t *testing.T) {
+	original := Config
+	t.Cleanup(func() { Config = original })
+
+	Config = Specification{
+		ProjectIDs:       []string{"plural-a"},
+		ProjectsAdvanced: ProjectsAdvanced{{ProjectID: "adv-a"}},
+	}
+	resolved := ResolvedProjects()
+	require.Len(t, resolved, 1)
+	assert.Equal(t, "adv-a", resolved[0].ProjectID)
+}
+
+func TestResolvedProjects_FallsBackToLegacy(t *testing.T) {
+	original := Config
+	t.Cleanup(func() { Config = original })
+
+	Config = Specification{ProjectID: "legacy-a"}
+	resolved := ResolvedProjects()
+	require.Len(t, resolved, 1)
+	assert.Equal(t, "legacy-a", resolved[0].ProjectID)
+	assert.Empty(t, resolved[0].ImpersonateServiceAccount)
+}
+
+func TestResolvedProjects_UsesPlural(t *testing.T) {
+	original := Config
+	t.Cleanup(func() { Config = original })
+
+	Config = Specification{ProjectIDs: []string{"plural-a", "plural-b"}}
+	resolved := ResolvedProjects()
+	require.Len(t, resolved, 2)
+	assert.Equal(t, "plural-a", resolved[0].ProjectID)
+	assert.Equal(t, "plural-b", resolved[1].ProjectID)
+}

--- a/e2e/integration_test.go
+++ b/e2e/integration_test.go
@@ -34,7 +34,7 @@ func TestWithMinikube(t *testing.T) {
 			return []string{
 				"--set", "logging.level=debug",
 				"--set", "gcp.projectID=" + mockProjectID,
-				"--set", "testing.computeEndpoint=http://host.minikube.internal:" + server.hostPort(),
+				"--set", "testing.computeEndpoint=http://host.minikube.internal:" + server.port(),
 			}
 		},
 	}

--- a/e2e/integration_test.go
+++ b/e2e/integration_test.go
@@ -5,43 +5,87 @@ package e2e
 
 import (
 	"context"
+	"testing"
+	"time"
+
 	"github.com/rs/zerolog/log"
+	"github.com/steadybit/action-kit/go/action_kit_api/v2"
 	"github.com/steadybit/action-kit/go/action_kit_test/e2e"
 	"github.com/steadybit/discovery-kit/go/discovery_kit_api"
 	"github.com/steadybit/extension-gcp/extvm"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"testing"
-	"time"
+)
+
+const (
+	mockProjectID = "mock-project"
+	mockVMName    = "test"
+	mockZone      = "us-central1-a"
 )
 
 func TestWithMinikube(t *testing.T) {
+	server := startMockComputeServer()
+	defer server.Close()
+
 	extFactory := e2e.HelmExtensionFactory{
 		Name: "extension-gcp",
 		Port: 8093,
 		ExtraArgs: func(m *e2e.Minikube) []string {
 			return []string{
 				"--set", "logging.level=debug",
+				"--set", "gcp.projectID=" + mockProjectID,
+				"--set", "testing.computeEndpoint=http://host.minikube.internal:" + server.hostPort(),
 			}
 		},
 	}
 
 	e2e.WithMinikube(t, e2e.DefaultMinikubeOpts(), &extFactory, []e2e.WithMinikubeTestCase{
-		{
-			Name: "discovery",
-			Test: testDiscovery,
-		},
+		{Name: "discovery", Test: testDiscovery},
+		{Name: "stop action", Test: testStopAction(server)},
 	})
 }
 
-// test the installation of the extension in minikube
-func testDiscovery(t *testing.T, m *e2e.Minikube, e *e2e.Extension) {
+func testDiscovery(t *testing.T, _ *e2e.Minikube, e *e2e.Extension) {
 	log.Info().Msg("Starting testDiscovery")
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
-	_, err := e2e.PollForTarget(ctx, e, extvm.TargetIDVM, func(target discovery_kit_api.Target) bool {
-		return e2e.HasAttribute(target, "gcp-vm.name", "test")
+	target, err := e2e.PollForTarget(ctx, e, extvm.TargetIDVM, func(target discovery_kit_api.Target) bool {
+		return e2e.HasAttribute(target, "gcp-vm.name", mockVMName)
 	})
-	// we do not have a real gcp vm running, so we expect an error
-	require.Error(t, err)
+	require.NoError(t, err)
+	assert.Equal(t, extvm.TargetIDVM, target.TargetType)
+	assert.True(t, e2e.HasAttribute(target, "gcp.project.id", mockProjectID))
+	assert.True(t, e2e.HasAttribute(target, "gcp.zone", mockZone))
+	assert.True(t, e2e.HasAttribute(target, "gcp-vm.id", "42"))
+}
+
+func testStopAction(server *mockComputeServer) func(t *testing.T, m *e2e.Minikube, e *e2e.Extension) {
+	return func(t *testing.T, _ *e2e.Minikube, e *e2e.Extension) {
+		log.Info().Msg("Starting testStopAction")
+		before := len(server.StopRequests())
+
+		exec, err := e.RunAction(
+			extvm.VirtualMachineStateActionId,
+			&action_kit_api.Target{
+				Name: mockVMName,
+				Attributes: map[string][]string{
+					"gcp-vm.name":    {mockVMName},
+					"gcp.zone":       {mockZone},
+					"gcp.project.id": {mockProjectID},
+				},
+			},
+			map[string]any{"action": "stop"},
+			nil,
+		)
+		require.NoError(t, err)
+		require.NoError(t, exec.Wait())
+
+		require.Eventually(t, func() bool {
+			return len(server.StopRequests()) > before
+		}, 10*time.Second, 200*time.Millisecond, "mock server did not record a stop request")
+
+		got := server.StopRequests()[len(server.StopRequests())-1]
+		assert.Equal(t, instanceRef{Project: mockProjectID, Zone: mockZone, Instance: mockVMName}, got)
+	}
 }

--- a/e2e/integration_test.go
+++ b/e2e/integration_test.go
@@ -79,7 +79,9 @@ func testStopAction(server *mockComputeServer) func(t *testing.T, m *e2e.Minikub
 			nil,
 		)
 		require.NoError(t, err)
-		require.NoError(t, exec.Wait())
+		// The action is instantaneous (no status poll, no stop hook) so exec.Wait() would
+		// block forever. Cancelling releases the harness goroutine immediately.
+		defer func() { _ = exec.Cancel() }()
 
 		require.Eventually(t, func() bool {
 			return len(server.StopRequests()) > before

--- a/e2e/mock_gcp_compute_server_test.go
+++ b/e2e/mock_gcp_compute_server_test.go
@@ -8,8 +8,8 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"regexp"
-	"strings"
 	"sync"
 
 	"github.com/rs/zerolog/log"
@@ -127,11 +127,13 @@ func (m *mockComputeServer) StopRequests() []instanceRef {
 	return append([]instanceRef(nil), m.stopRequests...)
 }
 
-// hostPort extracts the "host:port" suffix of the mock server URL, suitable for
-// constructing an endpoint reachable from inside minikube via host.minikube.internal.
-func (m *mockComputeServer) hostPort() string {
-	u := m.Server.URL
-	u = strings.TrimPrefix(u, "http://")
-	u = strings.TrimPrefix(u, "https://")
-	return u
+// port returns the port the mock server is listening on. The host part of the
+// server URL is bound to 0.0.0.0 and is not reachable from inside a minikube
+// pod, so callers combine this port with `host.minikube.internal`.
+func (m *mockComputeServer) port() string {
+	u, err := url.Parse(m.Server.URL)
+	if err != nil {
+		panic(fmt.Sprintf("mock compute server: cannot parse URL %q: %v", m.Server.URL, err))
+	}
+	return u.Port()
 }

--- a/e2e/mock_gcp_compute_server_test.go
+++ b/e2e/mock_gcp_compute_server_test.go
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2026 Steadybit GmbH
+
+package e2e
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"strings"
+	"sync"
+
+	"github.com/rs/zerolog/log"
+)
+
+// mockComputeServer is an in-process HTTP server that mimics just enough of the
+// Compute Engine REST API to exercise the extension-gcp discovery and state-change
+// actions during e2e tests.
+type mockComputeServer struct {
+	*httptest.Server
+	mu           sync.Mutex
+	stopRequests []instanceRef
+}
+
+type instanceRef struct {
+	Project  string
+	Zone     string
+	Instance string
+}
+
+var (
+	aggregatedListPath = regexp.MustCompile(`^/compute/v1/projects/([^/]+)/aggregated/instances$`)
+	stopInstancePath   = regexp.MustCompile(`^/compute/v1/projects/([^/]+)/zones/([^/]+)/instances/([^/]+)/stop$`)
+)
+
+func startMockComputeServer() *mockComputeServer {
+	listener, err := net.Listen("tcp", "0.0.0.0:0")
+	if err != nil {
+		panic(fmt.Sprintf("mock compute server: failed to listen: %v", err))
+	}
+	m := &mockComputeServer{}
+	m.Server = &httptest.Server{
+		Listener: listener,
+		Config:   &http.Server{Handler: http.HandlerFunc(m.handle)},
+	}
+	m.Server.Start()
+	log.Info().Str("url", m.Server.URL).Msg("Started mock GCP Compute server")
+	return m
+}
+
+func (m *mockComputeServer) handle(w http.ResponseWriter, r *http.Request) {
+	log.Info().Str("path", r.URL.Path).Str("method", r.Method).Msg("Mock Compute request received")
+
+	if match := aggregatedListPath.FindStringSubmatch(r.URL.Path); match != nil && r.Method == http.MethodGet {
+		m.writeAggregatedList(w, match[1])
+		return
+	}
+	if match := stopInstancePath.FindStringSubmatch(r.URL.Path); match != nil && r.Method == http.MethodPost {
+		m.recordStop(match[1], match[2], match[3])
+		writeOperation(w, "stop", match[2])
+		return
+	}
+
+	http.NotFound(w, r)
+}
+
+func (m *mockComputeServer) writeAggregatedList(w http.ResponseWriter, project string) {
+	body := fmt.Sprintf(`{
+  "kind": "compute#instanceAggregatedList",
+  "id": "projects/%s/aggregated/instances",
+  "items": {
+    "zones/us-central1-a": {
+      "instances": [
+        {
+          "kind": "compute#instance",
+          "id": "42",
+          "creationTimestamp": "2026-01-01T00:00:00.000-00:00",
+          "name": "test",
+          "description": "mock instance",
+          "machineType": "https://www.googleapis.com/compute/v1/projects/%s/zones/us-central1-a/machineTypes/e2-medium",
+          "status": "RUNNING",
+          "zone": "https://www.googleapis.com/compute/v1/projects/%s/zones/us-central1-a",
+          "cpuPlatform": "Intel Broadwell",
+          "hostname": "test",
+          "labels": {"team": "platform"}
+        }
+      ]
+    },
+    "zones/us-central1-b": {
+      "warning": {
+        "code": "NO_RESULTS_ON_PAGE",
+        "message": "There are no results for scope 'zones/us-central1-b' on this page."
+      }
+    }
+  },
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/%s/aggregated/instances"
+}`, project, project, project, project)
+	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
+	_, _ = w.Write([]byte(body))
+}
+
+func writeOperation(w http.ResponseWriter, opType, zone string) {
+	body := fmt.Sprintf(`{
+  "kind": "compute#operation",
+  "id": "1",
+  "name": "operation-mock",
+  "operationType": "%s",
+  "status": "DONE",
+  "progress": 100,
+  "zone": "https://www.googleapis.com/compute/v1/zones/%s"
+}`, opType, zone)
+	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
+	_, _ = w.Write([]byte(body))
+}
+
+func (m *mockComputeServer) recordStop(project, zone, instance string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.stopRequests = append(m.stopRequests, instanceRef{Project: project, Zone: zone, Instance: instance})
+}
+
+func (m *mockComputeServer) StopRequests() []instanceRef {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]instanceRef(nil), m.stopRequests...)
+}
+
+// hostPort extracts the "host:port" suffix of the mock server URL, suitable for
+// constructing an endpoint reachable from inside minikube via host.minikube.internal.
+func (m *mockComputeServer) hostPort() string {
+	u := m.Server.URL
+	u = strings.TrimPrefix(u, "http://")
+	u = strings.TrimPrefix(u, "https://")
+	return u
+}

--- a/extvm/client.go
+++ b/extvm/client.go
@@ -1,26 +1,17 @@
 package extvm
 
 import (
-	compute "cloud.google.com/go/compute/apiv1"
 	"context"
+
+	compute "cloud.google.com/go/compute/apiv1"
 	"github.com/rs/zerolog/log"
-	"github.com/steadybit/extension-gcp/config"
-	"google.golang.org/api/option"
+	"github.com/steadybit/extension-gcp/utils"
 )
 
-func getGcpInstancesClient(ctx context.Context) (*compute.InstancesClient, error) {
-	if config.Config.CredentialsKeyfilePath != "" {
-		client, err := compute.NewInstancesRESTClient(ctx, option.WithCredentialsFile(config.Config.CredentialsKeyfilePath))
-		if err != nil {
-			log.Error().Err(err).Msgf("Failed to create GCP client via file.")
-			return nil, err
-		}
-		return client, nil
-	}
-
-	client, err := compute.NewInstancesRESTClient(ctx)
+func newInstancesClientForAccess(ctx context.Context, access *utils.GcpAccess) (*compute.InstancesClient, error) {
+	client, err := compute.NewInstancesRESTClient(ctx, access.ClientOptions...)
 	if err != nil {
-		log.Error().Err(err).Msgf("Failed to create GCP client.")
+		log.Error().Err(err).Str("project", access.ProjectID).Msg("Failed to create GCP instances client.")
 		return nil, err
 	}
 	return client, nil

--- a/extvm/vm_attack_state.go
+++ b/extvm/vm_attack_state.go
@@ -12,12 +12,13 @@ import (
 	"github.com/googleapis/gax-go/v2"
 	"github.com/steadybit/action-kit/go/action_kit_api/v2"
 	"github.com/steadybit/action-kit/go/action_kit_sdk"
+	"github.com/steadybit/extension-gcp/utils"
 	extension_kit "github.com/steadybit/extension-kit"
 	"github.com/steadybit/extension-kit/extbuild"
 )
 
 type virtualMachineStateAction struct {
-	clientProvider func(ctx context.Context) (virtualMachineStateChangeApi, error)
+	clientProvider func(ctx context.Context, projectID string) (virtualMachineStateChangeApi, error)
 }
 
 var _ action_kit_sdk.Action[VirtualMachineStateChangeState] = (*virtualMachineStateAction)(nil)
@@ -129,7 +130,7 @@ func (e *virtualMachineStateAction) Prepare(_ context.Context, state *VirtualMac
 }
 
 func (e *virtualMachineStateAction) Start(ctx context.Context, state *VirtualMachineStateChangeState) (*action_kit_api.StartResult, error) {
-	client, err := e.clientProvider(ctx)
+	client, err := e.clientProvider(ctx, state.ProjectId)
 	if err != nil {
 		return nil, extension_kit.ToError("Failed to initialize gcp client", err)
 	}
@@ -169,6 +170,10 @@ func (e *virtualMachineStateAction) Start(ctx context.Context, state *VirtualMac
 	return nil, nil
 }
 
-func defaultClientProvider(ctx context.Context) (virtualMachineStateChangeApi, error) {
-	return getGcpInstancesClient(ctx)
+func defaultClientProvider(ctx context.Context, projectID string) (virtualMachineStateChangeApi, error) {
+	access, err := utils.GetGcpAccess(projectID)
+	if err != nil {
+		return nil, err
+	}
+	return newInstancesClientForAccess(ctx, access)
 }

--- a/extvm/vm_attack_state_test.go
+++ b/extvm/vm_attack_state_test.go
@@ -163,7 +163,7 @@ func TestGcpVirtualMachineStateAction_Suspend(t *testing.T) {
 		return true
 	})).Return(nil, nil)
 
-	action := virtualMachineStateAction{clientProvider: func(ctx context.Context) (virtualMachineStateChangeApi, error) {
+	action := virtualMachineStateAction{clientProvider: func(ctx context.Context, projectID string) (virtualMachineStateChangeApi, error) {
 		return api, nil
 	}}
 
@@ -192,7 +192,7 @@ func TestGcpVirtualMachineStateAction_Delete(t *testing.T) {
 		return true
 	})).Return(nil, nil)
 
-	action := virtualMachineStateAction{clientProvider: func(ctx context.Context) (virtualMachineStateChangeApi, error) {
+	action := virtualMachineStateAction{clientProvider: func(ctx context.Context, projectID string) (virtualMachineStateChangeApi, error) {
 		return api, nil
 	}}
 
@@ -221,7 +221,7 @@ func TestGcpVirtualMachineStateAction_Stop(t *testing.T) {
 		return true
 	})).Return(nil, nil)
 
-	action := virtualMachineStateAction{clientProvider: func(ctx context.Context) (virtualMachineStateChangeApi, error) {
+	action := virtualMachineStateAction{clientProvider: func(ctx context.Context, projectID string) (virtualMachineStateChangeApi, error) {
 		return api, nil
 	}}
 
@@ -250,7 +250,7 @@ func TestGcpVirtualMachineStateAction_Reset(t *testing.T) {
 		return true
 	})).Return(nil, nil)
 
-	action := virtualMachineStateAction{clientProvider: func(ctx context.Context) (virtualMachineStateChangeApi, error) {
+	action := virtualMachineStateAction{clientProvider: func(ctx context.Context, projectID string) (virtualMachineStateChangeApi, error) {
 		return api, nil
 	}}
 
@@ -278,7 +278,7 @@ func TestStartVirtualMachineStateChangeForwardsError(t *testing.T) {
 		require.Equal(t, "my-vm", req.Instance)
 		return true
 	})).Return(nil, errors.New("expected"))
-	action := virtualMachineStateAction{clientProvider: func(ctx context.Context) (virtualMachineStateChangeApi, error) {
+	action := virtualMachineStateAction{clientProvider: func(ctx context.Context, projectID string) (virtualMachineStateChangeApi, error) {
 		return api, nil
 	}}
 

--- a/extvm/vm_discovery.go
+++ b/extvm/vm_discovery.go
@@ -16,6 +16,7 @@ import (
 	"github.com/steadybit/discovery-kit/go/discovery_kit_commons"
 	"github.com/steadybit/discovery-kit/go/discovery_kit_sdk"
 	"github.com/steadybit/extension-gcp/config"
+	"github.com/steadybit/extension-gcp/utils"
 	"github.com/steadybit/extension-kit/extbuild"
 	"github.com/steadybit/extension-kit/extutil"
 	"google.golang.org/api/iterator"
@@ -201,29 +202,26 @@ func (d *vmDiscovery) DescribeAttributes() []discovery_kit_api.AttributeDescript
 }
 
 func (d *vmDiscovery) DiscoverTargets(ctx context.Context) ([]discovery_kit_api.Target, error) {
-	instancesClient, err := getGcpInstancesClient(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get client: %w", err)
-	}
-	defer func() { _ = instancesClient.Close() }()
+	return utils.ForEveryConfiguredGcpAccess(func(access *utils.GcpAccess, ctx context.Context) ([]discovery_kit_api.Target, error) {
+		client, err := newInstancesClientForAccess(ctx, access)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get client for project '%s': %w", access.ProjectID, err)
+		}
+		defer func() { _ = client.Close() }()
 
-	instances, err := getAllVirtualMachinesInstances(ctx, instancesClient)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get all virtual machines: %w", err)
-	}
-	return instancesToTargets(instances), nil
+		instances, err := getAllVirtualMachinesInstances(ctx, client, access.ProjectID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to list virtual machines in project '%s': %w", access.ProjectID, err)
+		}
+		return instancesToTargets(instances, access.ProjectID), nil
+	}, ctx, "virtual-machines")
 }
 
 type GCPInstancesApi interface {
 	AggregatedList(ctx context.Context, req *computepb.AggregatedListInstancesRequest, opts ...gax.CallOption) *compute.InstancesScopedListPairIterator
 }
 
-func getAllVirtualMachinesInstances(ctx context.Context, client GCPInstancesApi) ([]*computepb.Instance, error) {
-	projectID := config.Config.ProjectID
-	if projectID == "" {
-		log.Error().Msgf("project id is not set")
-		return nil, errors.New("project id is not set")
-	}
+func getAllVirtualMachinesInstances(ctx context.Context, client GCPInstancesApi, projectID string) ([]*computepb.Instance, error) {
 	req := &computepb.AggregatedListInstancesRequest{
 		Project: projectID,
 	}
@@ -251,15 +249,15 @@ func getAllVirtualMachinesInstances(ctx context.Context, client GCPInstancesApi)
 	}
 	return allInstances, nil
 }
-func instancesToTargets(instances []*computepb.Instance) []discovery_kit_api.Target {
+func instancesToTargets(instances []*computepb.Instance, projectID string) []discovery_kit_api.Target {
 	targets := make([]discovery_kit_api.Target, 0)
 	for _, instance := range instances {
-		targets = instanceToTarget(instance, targets)
+		targets = instanceToTarget(instance, projectID, targets)
 	}
 	return discovery_kit_commons.ApplyAttributeExcludes(targets, config.Config.DiscoveryAttributesExcludesVM)
 }
 
-func instanceToTarget(instance *computepb.Instance, targets []discovery_kit_api.Target) []discovery_kit_api.Target {
+func instanceToTarget(instance *computepb.Instance, projectID string, targets []discovery_kit_api.Target) []discovery_kit_api.Target {
 	attributes := make(map[string][]string)
 
 	attributes["gcp-vm.name"] = []string{getStringValue(instance.Name)}
@@ -274,7 +272,7 @@ func instanceToTarget(instance *computepb.Instance, targets []discovery_kit_api.
 	attributes["gcp-vm.status-message"] = []string{getStringValue(instance.StatusMessage)}
 	attributes["gcp.zone-url"] = []string{getStringValue(instance.Zone)}
 	attributes["gcp.zone"] = []string{getZone(instance)}
-	attributes["gcp.project.id"] = []string{config.Config.ProjectID}
+	attributes["gcp.project.id"] = []string{projectID}
 	attributes["gcp-kubernetes-engine.cluster.name"] = []string{getMetadata(instance.Metadata, "cluster-name")}
 	attributes["gcp-kubernetes-engine.cluster.location"] = []string{getMetadata(instance.Metadata, "cluster-location")}
 

--- a/extvm/vm_discovery_test.go
+++ b/extvm/vm_discovery_test.go
@@ -1,14 +1,15 @@
 package extvm
 
 import (
+	"context"
+	"testing"
+
 	compute "cloud.google.com/go/compute/apiv1"
 	"cloud.google.com/go/compute/apiv1/computepb"
-	"context"
 	"github.com/googleapis/gax-go/v2"
 	"github.com/steadybit/extension-gcp/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	"testing"
 )
 
 type gcpResourceGraphClientMock struct {
@@ -25,7 +26,6 @@ func (m *gcpResourceGraphClientMock) AggregatedList(ctx context.Context, req *co
 
 func TestInstancesToTargets(t *testing.T) {
 	// Given
-	config.Config.ProjectID = "p_extension_gcp"
 	config.Config.DiscoveryAttributesExcludesVM = []string{"gcp-vm.label.tag1"}
 	id := uint64(42)
 	instances := []*computepb.Instance{
@@ -63,7 +63,7 @@ func TestInstancesToTargets(t *testing.T) {
 	}
 
 	// When
-	targets := instancesToTargets(instances)
+	targets := instancesToTargets(instances, "p_extension_gcp")
 
 	// Then
 	assert.Equal(t, 1, len(targets))
@@ -90,16 +90,4 @@ func TestInstancesToTargets(t *testing.T) {
 	assert.NotContains(t, target.Attributes, "gcp-vm.label.tag1")
 	_, present := target.Attributes["label.name"]
 	assert.False(t, present)
-}
-
-func TestMissingProjectId(t *testing.T) {
-	// Given
-	mockedApi := new(gcpResourceGraphClientMock)
-	config.Config.ProjectID = ""
-
-	// When
-	_, err := getAllVirtualMachinesInstances(context.Background(), mockedApi)
-
-	// Then
-	assert.Equal(t, err.Error(), "project id is not set")
 }

--- a/go.sum
+++ b/go.sum
@@ -210,6 +210,8 @@ github.com/zmwangx/debounce v1.0.0 h1:Dyf+WfLESjc2bqFKHgI1dZTW9oh6CJm8SBDkhXrwLB
 github.com/zmwangx/debounce v1.0.0/go.mod h1:U+/QHt+bSMdUh8XKOb6U+MQV5Ew4eS8M3ua5WJ7Ns6I=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
+go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.67.0 h1:yI1/OhfEPy7J9eoa6Sj051C7n5dvpj0QX8g4sRchg04=
+go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.67.0/go.mod h1:NoUCKYWK+3ecatC4HjkRktREheMeEtrXoQxrqYFeHSc=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.67.0 h1:OyrsyzuttWTSur2qN/Lm0m2a8yqyIjUVBZcxFPuXq2o=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.67.0/go.mod h1:C2NGBr+kAB4bk3xtMXfZ94gqFDtg/GkI7e9zqGh5Beg=
 go.opentelemetry.io/otel v1.43.0 h1:mYIM03dnh5zfN7HautFE4ieIig9amkNANT+xcVxAj9I=

--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/steadybit/discovery-kit/go/discovery_kit_sdk"
 	"github.com/steadybit/extension-gcp/config"
 	"github.com/steadybit/extension-gcp/extvm"
+	"github.com/steadybit/extension-gcp/utils"
 	"github.com/steadybit/extension-kit/extbuild"
 	"github.com/steadybit/extension-kit/exthealth"
 	"github.com/steadybit/extension-kit/exthttp"
@@ -46,6 +47,7 @@ func main() {
 	// configuration obtained from environment variables.
 	config.ParseConfiguration()
 	config.ValidateConfiguration()
+	utils.InitializeGcpAccess(config.Config)
 
 	// This call registers a handler for the extension's root path. This is the path initially accessed
 	// by the Steadybit agent to obtain the extension's capabilities.

--- a/utils/gcp_access.go
+++ b/utils/gcp_access.go
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2026 steadybit GmbH. All rights reserved.
+ */
+
+package utils
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/rs/zerolog/log"
+	"github.com/steadybit/discovery-kit/go/discovery_kit_api"
+	"github.com/steadybit/extension-gcp/config"
+	"google.golang.org/api/impersonate"
+	"google.golang.org/api/option"
+)
+
+// GcpAccess represents the configured access to a single GCP project, including any pre-built client options
+// required to authenticate (impersonation token sources or keyfile credentials).
+type GcpAccess struct {
+	ProjectID     string
+	ClientOptions []option.ClientOption
+}
+
+var projects map[string]GcpAccess
+
+// InitializeGcpAccess builds one GcpAccess per configured project. Must be called once after config.ValidateConfiguration.
+// Projects whose client options fail to build are logged and skipped; the extension continues to operate with the
+// remaining projects.
+func InitializeGcpAccess(spec config.Specification) {
+	projects = make(map[string]GcpAccess)
+	for _, p := range config.ResolvedProjects() {
+		opts, err := buildClientOptions(spec.CredentialsKeyfilePath, p.ImpersonateServiceAccount)
+		if err != nil {
+			log.Error().Err(err).Str("project", p.ProjectID).Msg("Failed to build GCP client options; project will be ignored until extension is restarted.")
+			continue
+		}
+		projects[p.ProjectID] = GcpAccess{ProjectID: p.ProjectID, ClientOptions: opts}
+		if p.ImpersonateServiceAccount != "" {
+			log.Info().Str("project", p.ProjectID).Str("impersonate", p.ImpersonateServiceAccount).Msg("Configured GCP project with service-account impersonation.")
+		} else {
+			log.Info().Str("project", p.ProjectID).Msg("Configured GCP project.")
+		}
+	}
+	if len(projects) == 0 {
+		log.Fatal().Msg("No usable GCP projects after client option initialization.")
+	}
+}
+
+func buildClientOptions(credentialsKeyfilePath, impersonateServiceAccount string) ([]option.ClientOption, error) {
+	var sourceOpts []option.ClientOption
+	if credentialsKeyfilePath != "" {
+		sourceOpts = append(sourceOpts, option.WithCredentialsFile(credentialsKeyfilePath))
+	}
+	if impersonateServiceAccount == "" {
+		return sourceOpts, nil
+	}
+	ts, err := impersonate.CredentialsTokenSource(context.Background(), impersonate.CredentialsConfig{
+		TargetPrincipal: impersonateServiceAccount,
+		Scopes:          []string{"https://www.googleapis.com/auth/cloud-platform"},
+	}, sourceOpts...)
+	if err != nil {
+		return nil, fmt.Errorf("create impersonation token source for '%s': %w", impersonateServiceAccount, err)
+	}
+	return []option.ClientOption{option.WithTokenSource(ts)}, nil
+}
+
+// GetGcpAccess returns the access entry for the given project ID, or an error if none is configured.
+func GetGcpAccess(projectID string) (*GcpAccess, error) {
+	a, ok := projects[projectID]
+	if !ok {
+		return nil, fmt.Errorf("no GCP access configured for project '%s'", projectID)
+	}
+	return &a, nil
+}
+
+// ForEveryConfiguredGcpAccess fans the supplier out across all configured projects using config.WorkerThreads goroutines.
+// Errors from the supplier are logged per-project and do not abort the overall discovery.
+func ForEveryConfiguredGcpAccess(
+	supplier func(access *GcpAccess, ctx context.Context) ([]discovery_kit_api.Target, error),
+	ctx context.Context,
+	discovery string,
+) ([]discovery_kit_api.Target, error) {
+	count := len(projects)
+	if count == 0 {
+		return []discovery_kit_api.Target{}, nil
+	}
+
+	workers := config.Config.WorkerThreads
+	if workers < 1 {
+		workers = 1
+	}
+	if workers > count {
+		workers = count
+	}
+
+	accessChan := make(chan GcpAccess, count)
+	resultsChan := make(chan []discovery_kit_api.Target, count)
+
+	for w := 1; w <= workers; w++ {
+		go func(worker int) {
+			for access := range accessChan {
+				log.Trace().Str("project", access.ProjectID).Int("worker", worker).Msgf("Collecting %s", discovery)
+				targets, err := supplier(&access, ctx)
+				if err != nil {
+					log.Err(err).Str("project", access.ProjectID).Msgf("Failed to collect %s", discovery)
+				}
+				resultsChan <- targets
+			}
+		}(w)
+	}
+
+	for _, a := range projects {
+		accessChan <- a
+	}
+	close(accessChan)
+
+	result := make([]discovery_kit_api.Target, 0)
+	for i := 0; i < count; i++ {
+		if targets := <-resultsChan; targets != nil {
+			result = append(result, targets...)
+		}
+	}
+	return result, nil
+}
+
+// SetProjectsForTest replaces the internal projects map. Intended for tests only.
+func SetProjectsForTest(entries map[string]GcpAccess) {
+	projects = entries
+}

--- a/utils/gcp_access.go
+++ b/utils/gcp_access.go
@@ -30,7 +30,7 @@ var projects map[string]GcpAccess
 func InitializeGcpAccess(spec config.Specification) {
 	projects = make(map[string]GcpAccess)
 	for _, p := range config.ResolvedProjects() {
-		opts, err := buildClientOptions(spec.CredentialsKeyfilePath, p.ImpersonateServiceAccount)
+		opts, err := buildClientOptions(spec, p.ImpersonateServiceAccount)
 		if err != nil {
 			log.Error().Err(err).Str("project", p.ProjectID).Msg("Failed to build GCP client options; project will be ignored until extension is restarted.")
 			continue
@@ -47,10 +47,15 @@ func InitializeGcpAccess(spec config.Specification) {
 	}
 }
 
-func buildClientOptions(credentialsKeyfilePath, impersonateServiceAccount string) ([]option.ClientOption, error) {
+func buildClientOptions(spec config.Specification, impersonateServiceAccount string) ([]option.ClientOption, error) {
+	if spec.ComputeEndpoint != "" {
+		log.Warn().Str("endpoint", spec.ComputeEndpoint).Msg("STEADYBIT_EXTENSION_COMPUTE_ENDPOINT is set; GCP clients will skip authentication. This must only be used for testing.")
+		return []option.ClientOption{option.WithEndpoint(spec.ComputeEndpoint), option.WithoutAuthentication()}, nil
+	}
+
 	var sourceOpts []option.ClientOption
-	if credentialsKeyfilePath != "" {
-		sourceOpts = append(sourceOpts, option.WithCredentialsFile(credentialsKeyfilePath))
+	if spec.CredentialsKeyfilePath != "" {
+		sourceOpts = append(sourceOpts, option.WithCredentialsFile(spec.CredentialsKeyfilePath))
 	}
 	if impersonateServiceAccount == "" {
 		return sourceOpts, nil

--- a/utils/gcp_access_test.go
+++ b/utils/gcp_access_test.go
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2026 steadybit GmbH. All rights reserved.
+ */
+
+package utils
+
+import (
+	"context"
+	"errors"
+	"sort"
+	"testing"
+
+	"github.com/steadybit/discovery-kit/go/discovery_kit_api"
+	"github.com/steadybit/extension-gcp/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetGcpAccess_NotFound(t *testing.T) {
+	t.Cleanup(func() { SetProjectsForTest(nil) })
+	SetProjectsForTest(map[string]GcpAccess{})
+
+	_, err := GetGcpAccess("missing")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "missing")
+}
+
+func TestGetGcpAccess_Found(t *testing.T) {
+	t.Cleanup(func() { SetProjectsForTest(nil) })
+	SetProjectsForTest(map[string]GcpAccess{
+		"proj-a": {ProjectID: "proj-a"},
+	})
+
+	got, err := GetGcpAccess("proj-a")
+	require.NoError(t, err)
+	assert.Equal(t, "proj-a", got.ProjectID)
+}
+
+func TestForEveryConfiguredGcpAccess_NoProjectsReturnsEmpty(t *testing.T) {
+	t.Cleanup(func() { SetProjectsForTest(nil) })
+	SetProjectsForTest(map[string]GcpAccess{})
+
+	targets, err := ForEveryConfiguredGcpAccess(func(*GcpAccess, context.Context) ([]discovery_kit_api.Target, error) {
+		t.Fatal("supplier should not be called when no projects are configured")
+		return nil, nil
+	}, context.Background(), "test")
+
+	require.NoError(t, err)
+	assert.Empty(t, targets)
+}
+
+func TestForEveryConfiguredGcpAccess_AggregatesAcrossProjects(t *testing.T) {
+	t.Cleanup(func() {
+		SetProjectsForTest(nil)
+		config.Config.WorkerThreads = 0
+	})
+	SetProjectsForTest(map[string]GcpAccess{
+		"proj-a": {ProjectID: "proj-a"},
+		"proj-b": {ProjectID: "proj-b"},
+	})
+	config.Config.WorkerThreads = 2
+
+	targets, err := ForEveryConfiguredGcpAccess(func(access *GcpAccess, _ context.Context) ([]discovery_kit_api.Target, error) {
+		return []discovery_kit_api.Target{
+			{Id: "vm-" + access.ProjectID, TargetType: "test", Attributes: map[string][]string{"gcp.project.id": {access.ProjectID}}},
+		}, nil
+	}, context.Background(), "test")
+
+	require.NoError(t, err)
+	require.Len(t, targets, 2)
+	sort.Slice(targets, func(i, j int) bool { return targets[i].Id < targets[j].Id })
+	assert.Equal(t, "vm-proj-a", targets[0].Id)
+	assert.Equal(t, "vm-proj-b", targets[1].Id)
+}
+
+func TestForEveryConfiguredGcpAccess_IsolatesErrorsPerProject(t *testing.T) {
+	t.Cleanup(func() {
+		SetProjectsForTest(nil)
+		config.Config.WorkerThreads = 0
+	})
+	SetProjectsForTest(map[string]GcpAccess{
+		"proj-a": {ProjectID: "proj-a"},
+		"proj-b": {ProjectID: "proj-b"},
+	})
+	config.Config.WorkerThreads = 1
+
+	targets, err := ForEveryConfiguredGcpAccess(func(access *GcpAccess, _ context.Context) ([]discovery_kit_api.Target, error) {
+		if access.ProjectID == "proj-a" {
+			return nil, errors.New("simulated project-a failure")
+		}
+		return []discovery_kit_api.Target{{Id: "vm-" + access.ProjectID, TargetType: "test"}}, nil
+	}, context.Background(), "test")
+
+	require.NoError(t, err)
+	require.Len(t, targets, 1)
+	assert.Equal(t, "vm-proj-b", targets[0].Id)
+}


### PR DESCRIPTION
## Summary
- Adds multi-project discovery support to extension-gcp, mirroring the multi-account pattern from extension-aws.
- Two modes: `STEADYBIT_EXTENSION_PROJECT_IDS` (CSV, shared credentials) and `STEADYBIT_EXTENSION_PROJECTS_ADVANCED` (JSON, per-project service-account impersonation).
- Legacy `STEADYBIT_EXTENSION_PROJECT_ID` kept; startup fails if set alongside either new var. Adds `STEADYBIT_EXTENSION_WORKER_THREADS` (default 1) for discovery fan-out.

## Details
- New `utils` package (`GcpAccess`, `InitializeGcpAccess`, `GetGcpAccess`, `ForEveryConfiguredGcpAccess`). Client options — including optional impersonation token sources — are built once per project at startup and reused per client call.
- `extvm/vm_discovery.go` now fans out via `ForEveryConfiguredGcpAccess`, and project ID is threaded through `getAllVirtualMachinesInstances` / `instancesToTargets` instead of read from global config.
- `extvm/vm_attack_state.go`'s `clientProvider` gains a `projectID` parameter; `defaultClientProvider` looks up the per-project access.
- Helm values: `gcp.projectIDs`, `gcp.projectsAdvanced`, `gcp.workerThreads` added; deployment template emits the corresponding env vars.
- README gets a multi-project + impersonation section (Token Creator prerequisite).
- Error isolation per project via the fan-out helper (one failing project does not block the others).

Refs BusinessMap ticket 15117.

## Test plan
- [x] `go build ./...`
- [x] `go test ./config/... ./utils/... ./extvm/...` — 32 passed
- [x] `helm unittest charts/steadybit-extension-gcp` — 25 tests / 24 snapshots passed
- [x] Manually verify discovery against two real GCP projects (shared credentials)
- [x] Manually verify discovery against two projects with distinct impersonation SAs
- [x] Manually verify that setting `STEADYBIT_EXTENSION_PROJECT_ID` together with `STEADYBIT_EXTENSION_PROJECT_IDS` aborts startup