### PR TITLE
docs: align CONTRIBUTING with canonical template

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,15 @@
 # Contributing
 
+## Prerequisites
+
+To build and run this extension locally, you need:
+
+- [Go](https://go.dev/dl/) 1.26 or later
+- [GNU Make](https://www.gnu.org/software/make/)
+- [GoReleaser](https://goreleaser.com/) (used by `make build`)
+- [Docker](https://www.docker.com/) (required for `make container` and container-based tests)
+- [Helm](https://helm.sh/docs/intro/install/) and [helm-unittest](https://github.com/helm-unittest/helm-unittest) (for chart development; `make charttesting` and `make chartlint`)
+
 ## Getting Started
 
 1. Clone the repository
@@ -9,14 +19,15 @@
 
 ## Tasks
 
-The `Makefile` in the project root contains commands to easily run common admin tasks:
+The `Makefile` in the project root contains commands to easily run common admin tasks. Run `make help` to list all available targets.
 
-| Command        | Meaning                                                                                               |
-|----------------|-------------------------------------------------------------------------------------------------------|
-| `$ make tidy`  | Format all code using `go fmt` and tidy the `go.mod` file.                                            |
-| `$ make audit` | Run `go vet`, `staticheck`, execute all tests and verify required modules.                            |
-| `$ make build` | Build a binary for the extension. Creates a file called `extension` in the repository root directory. |
-| `$ make run`   | Build and then run the created binary.                                                                |
+| Command            | Meaning                                                                                               |
+|--------------------|-------------------------------------------------------------------------------------------------------|
+| `$ make tidy`      | Format all code using `go fmt` and tidy the `go.mod` file.                                            |
+| `$ make audit`     | Run `go vet`, `staticcheck`, execute all tests and verify required modules.                           |
+| `$ make build`     | Build a binary for the extension. Creates a file called `extension` in the repository root directory. |
+| `$ make run`       | Build and then run the created binary.                                                                |
+| `$ make container` | Build the container image (`extension-gcp:latest`) using Docker buildx.                               |
 
 ## Releasing the Code/Docker Image
 


### PR DESCRIPTION
## Summary

Standardise the CONTRIBUTING.md across Steadybit Go extensions.

- Adds an explicit **Prerequisites** section listing required build tools (Go, GNU Make, GoReleaser, Docker, Helm + helm-unittest) with versions.
- Documents the available `Makefile` targets (`tidy`, `audit`, `build`, `run`, `container`) and points to `make help` for the full list.
- Keeps the existing Releasing / Helm Chart / CLA sections intact, only restructured for consistency.

Part of a cross-repository alignment pass so contributors get the same onboarding experience in every extension.