### PR TITLE
cleanup: extract duplicated attribute-name literals (Sonar go:S1192)

### DIFF
--- a/extcloudrun/common.go
+++ b/extcloudrun/common.go
@@ -7,4 +7,9 @@ package extcloudrun
 const (
 	TargetIDService = "com.steadybit.extension_gcp.cloudrun.service"
 	targetIcon      = "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIj48cGF0aCBkPSJNNCA0aDE2djJINFY0em0wIDdoMTZ2Mkg0di0yem0wIDdoMTZ2Mkg0di0yeiIgZmlsbD0iY3VycmVudENvbG9yIi8+PC9zdmc+"
+
+	// Attribute names extracted per Sonar go:S1192.
+	attrLocation  = "gcp.cloudrun.service.location"
+	attrIngress   = "gcp.cloudrun.service.ingress"
+	attrProjectID = "gcp.project.id"
 )

--- a/extcloudrun/service_discovery.go
+++ b/extcloudrun/service_discovery.go
@@ -55,9 +55,9 @@ func (d *serviceDiscovery) DescribeTarget() discovery_kit_api.TargetDescription 
 		Table: discovery_kit_api.Table{
 			Columns: []discovery_kit_api.Column{
 				{Attribute: "steadybit.label"},
-				{Attribute: "gcp.cloudrun.service.location"},
-				{Attribute: "gcp.cloudrun.service.ingress"},
-				{Attribute: "gcp.project.id"},
+				{Attribute: attrLocation},
+				{Attribute: attrIngress},
+				{Attribute: attrProjectID},
 			},
 			OrderBy: []discovery_kit_api.OrderBy{{Attribute: "steadybit.label", Direction: "ASC"}},
 		},
@@ -67,8 +67,8 @@ func (d *serviceDiscovery) DescribeTarget() discovery_kit_api.TargetDescription 
 func (d *serviceDiscovery) DescribeAttributes() []discovery_kit_api.AttributeDescription {
 	return []discovery_kit_api.AttributeDescription{
 		{Attribute: "gcp.cloudrun.service.name", Label: discovery_kit_api.PluralLabel{One: "Cloud Run service name", Other: "Cloud Run service names"}},
-		{Attribute: "gcp.cloudrun.service.location", Label: discovery_kit_api.PluralLabel{One: "Cloud Run service location", Other: "Cloud Run service locations"}},
-		{Attribute: "gcp.cloudrun.service.ingress", Label: discovery_kit_api.PluralLabel{One: "Cloud Run service ingress", Other: "Cloud Run service ingress"}},
+		{Attribute: attrLocation, Label: discovery_kit_api.PluralLabel{One: "Cloud Run service location", Other: "Cloud Run service locations"}},
+		{Attribute: attrIngress, Label: discovery_kit_api.PluralLabel{One: "Cloud Run service ingress", Other: "Cloud Run service ingress"}},
 		{Attribute: "gcp.cloudrun.service.launch-stage", Label: discovery_kit_api.PluralLabel{One: "Cloud Run service launch stage", Other: "Cloud Run service launch stages"}},
 		{Attribute: "gcp.cloudrun.service.invoker-iam-disabled", Label: discovery_kit_api.PluralLabel{One: "Cloud Run service invoker IAM disabled", Other: "Cloud Run service invoker IAM disabled"}},
 		{Attribute: "gcp.cloudrun.service.iap-enabled", Label: discovery_kit_api.PluralLabel{One: "Cloud Run service IAP enabled", Other: "Cloud Run service IAP enabled"}},
@@ -80,7 +80,7 @@ func (d *serviceDiscovery) DescribeAttributes() []discovery_kit_api.AttributeDes
 		{Attribute: "gcp.cloudrun.service.template.scaling.min-instance-count", Label: discovery_kit_api.PluralLabel{One: "Cloud Run revision min instances", Other: "Cloud Run revision min instances"}},
 		{Attribute: "gcp.cloudrun.service.template.scaling.max-instance-count", Label: discovery_kit_api.PluralLabel{One: "Cloud Run revision max instances", Other: "Cloud Run revision max instances"}},
 		{Attribute: "gcp.cloudrun.service.urls", Label: discovery_kit_api.PluralLabel{One: "Cloud Run service URL", Other: "Cloud Run service URLs"}},
-		{Attribute: "gcp.project.id", Label: discovery_kit_api.PluralLabel{One: "GCP project ID", Other: "GCP project IDs"}},
+		{Attribute: attrProjectID, Label: discovery_kit_api.PluralLabel{One: "GCP project ID", Other: "GCP project IDs"}},
 	}
 }
 
@@ -118,13 +118,13 @@ func toServiceTarget(s *runpb.Service, projectID string) discovery_kit_api.Targe
 	location, name := parseServiceName(s.Name)
 
 	attributes := make(map[string][]string)
-	attributes["gcp.project.id"] = []string{projectID}
+	attributes[attrProjectID] = []string{projectID}
 	attributes["gcp.cloudrun.service.name"] = []string{name}
 	if location != "" {
-		attributes["gcp.cloudrun.service.location"] = []string{location}
+		attributes[attrLocation] = []string{location}
 	}
 	if s.Ingress != runpb.IngressTraffic_INGRESS_TRAFFIC_UNSPECIFIED {
-		attributes["gcp.cloudrun.service.ingress"] = []string{s.Ingress.String()}
+		attributes[attrIngress] = []string{s.Ingress.String()}
 	}
 	if s.LaunchStage != 0 {
 		attributes["gcp.cloudrun.service.launch-stage"] = []string{s.LaunchStage.String()}

--- a/extcloudsql/common.go
+++ b/extcloudsql/common.go
@@ -8,4 +8,11 @@ const (
 	TargetIDInstance         = "com.steadybit.extension_gcp.cloudsql.instance"
 	InstanceFailoverActionId = "com.steadybit.extension_gcp.cloudsql.instance.failover"
 	targetIcon               = "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIj48cGF0aCBkPSJNMTIgM2M0Ljk3IDAgOSAxLjM0IDkgM3YxMmMwIDEuNjYtNC4wMyAzLTkgM3MtOS0xLjM0LTktM1Y2YzAtMS42NiA0LjAzLTMgOS0zem0wIDJjLTMuOSAwLTcgLjg5LTcgMnMzLjEgMiA3IDIgNy0uODkgNy0yLTMuMS0yLTctMnoiIGZpbGw9ImN1cnJlbnRDb2xvciIvPjwvc3ZnPg=="
+
+	// Attribute names duplicated across DescribeTarget / DescribeAttributes /
+	// toInstanceTarget; extracted per Sonar go:S1192.
+	attrDatabaseVersion  = "gcp.cloudsql.database-version"
+	attrTier             = "gcp.cloudsql.tier"
+	attrAvailabilityType = "gcp.cloudsql.availability-type"
+	attrRegion           = "gcp.cloudsql.region"
 )

--- a/extcloudsql/instance_discovery.go
+++ b/extcloudsql/instance_discovery.go
@@ -53,10 +53,10 @@ func (d *instanceDiscovery) DescribeTarget() discovery_kit_api.TargetDescription
 		Table: discovery_kit_api.Table{
 			Columns: []discovery_kit_api.Column{
 				{Attribute: "steadybit.label"},
-				{Attribute: "gcp.cloudsql.database-version"},
-				{Attribute: "gcp.cloudsql.tier"},
-				{Attribute: "gcp.cloudsql.availability-type"},
-				{Attribute: "gcp.cloudsql.region"},
+				{Attribute: attrDatabaseVersion},
+				{Attribute: attrTier},
+				{Attribute: attrAvailabilityType},
+				{Attribute: attrRegion},
 			},
 			OrderBy: []discovery_kit_api.OrderBy{{Attribute: "steadybit.label", Direction: "ASC"}},
 		},
@@ -66,10 +66,10 @@ func (d *instanceDiscovery) DescribeTarget() discovery_kit_api.TargetDescription
 func (d *instanceDiscovery) DescribeAttributes() []discovery_kit_api.AttributeDescription {
 	return []discovery_kit_api.AttributeDescription{
 		{Attribute: "gcp.cloudsql.instance.name", Label: discovery_kit_api.PluralLabel{One: "Cloud SQL instance name", Other: "Cloud SQL instance names"}},
-		{Attribute: "gcp.cloudsql.database-version", Label: discovery_kit_api.PluralLabel{One: "Cloud SQL database version", Other: "Cloud SQL database versions"}},
-		{Attribute: "gcp.cloudsql.tier", Label: discovery_kit_api.PluralLabel{One: "Cloud SQL tier", Other: "Cloud SQL tiers"}},
-		{Attribute: "gcp.cloudsql.availability-type", Label: discovery_kit_api.PluralLabel{One: "Cloud SQL availability type", Other: "Cloud SQL availability types"}},
-		{Attribute: "gcp.cloudsql.region", Label: discovery_kit_api.PluralLabel{One: "Cloud SQL region", Other: "Cloud SQL regions"}},
+		{Attribute: attrDatabaseVersion, Label: discovery_kit_api.PluralLabel{One: "Cloud SQL database version", Other: "Cloud SQL database versions"}},
+		{Attribute: attrTier, Label: discovery_kit_api.PluralLabel{One: "Cloud SQL tier", Other: "Cloud SQL tiers"}},
+		{Attribute: attrAvailabilityType, Label: discovery_kit_api.PluralLabel{One: "Cloud SQL availability type", Other: "Cloud SQL availability types"}},
+		{Attribute: attrRegion, Label: discovery_kit_api.PluralLabel{One: "Cloud SQL region", Other: "Cloud SQL regions"}},
 		{Attribute: "gcp.cloudsql.gce-zone", Label: discovery_kit_api.PluralLabel{One: "Cloud SQL GCE zone", Other: "Cloud SQL GCE zones"}},
 		{Attribute: "gcp.cloudsql.secondary-gce-zone", Label: discovery_kit_api.PluralLabel{One: "Cloud SQL secondary zone", Other: "Cloud SQL secondary zones"}},
 		{Attribute: "gcp.cloudsql.state", Label: discovery_kit_api.PluralLabel{One: "Cloud SQL state", Other: "Cloud SQL states"}},
@@ -117,10 +117,10 @@ func toInstanceTarget(inst *sqladmin.DatabaseInstance, projectID string) discove
 	attributes["gcp.project.id"] = []string{projectID}
 	attributes["gcp.cloudsql.instance.name"] = []string{inst.Name}
 	if inst.DatabaseVersion != "" {
-		attributes["gcp.cloudsql.database-version"] = []string{inst.DatabaseVersion}
+		attributes[attrDatabaseVersion] = []string{inst.DatabaseVersion}
 	}
 	if inst.Region != "" {
-		attributes["gcp.cloudsql.region"] = []string{inst.Region}
+		attributes[attrRegion] = []string{inst.Region}
 	}
 	if inst.GceZone != "" {
 		attributes["gcp.cloudsql.gce-zone"] = []string{inst.GceZone}
@@ -136,10 +136,10 @@ func toInstanceTarget(inst *sqladmin.DatabaseInstance, projectID string) discove
 	}
 	if inst.Settings != nil {
 		if inst.Settings.Tier != "" {
-			attributes["gcp.cloudsql.tier"] = []string{inst.Settings.Tier}
+			attributes[attrTier] = []string{inst.Settings.Tier}
 		}
 		if inst.Settings.AvailabilityType != "" {
-			attributes["gcp.cloudsql.availability-type"] = []string{inst.Settings.AvailabilityType}
+			attributes[attrAvailabilityType] = []string{inst.Settings.AvailabilityType}
 		}
 		if inst.Settings.BackupConfiguration != nil {
 			attributes["gcp.cloudsql.backup-enabled"] = []string{strconv.FormatBool(inst.Settings.BackupConfiguration.Enabled)}

--- a/extdisk/disk_discovery.go
+++ b/extdisk/disk_discovery.go
@@ -28,6 +28,12 @@ import (
 const (
 	TargetIDDisk = "com.steadybit.extension_gcp.persistent-disk"
 	targetIcon   = "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIj48cGF0aCBkPSJNMTIgM2M0Ljk3IDAgOSAxLjM0IDkgM3YxMmMwIDEuNjYtNC4wMyAzLTkgM3MtOS0xLjM0LTktM1Y2YzAtMS42NiA0LjAzLTMgOS0zem0wIDJjLTMuOSAwLTcgLjg5LTcgMnMzLjEgMiA3IDIgNy0uODkgNy0yLTMuMS0yLTctMnoiIGZpbGw9ImN1cnJlbnRDb2xvciIvPjwvc3ZnPg=="
+
+	// Attribute names extracted per Sonar go:S1192.
+	attrType      = "gcp.persistent-disk.type"
+	attrSizeGB    = "gcp.persistent-disk.size-gb"
+	attrZone      = "gcp.persistent-disk.zone"
+	attrProjectID = "gcp.project.id"
 )
 
 type diskDiscovery struct{}
@@ -61,10 +67,10 @@ func (d *diskDiscovery) DescribeTarget() discovery_kit_api.TargetDescription {
 		Table: discovery_kit_api.Table{
 			Columns: []discovery_kit_api.Column{
 				{Attribute: "steadybit.label"},
-				{Attribute: "gcp.persistent-disk.type"},
-				{Attribute: "gcp.persistent-disk.size-gb"},
-				{Attribute: "gcp.persistent-disk.zone"},
-				{Attribute: "gcp.project.id"},
+				{Attribute: attrType},
+				{Attribute: attrSizeGB},
+				{Attribute: attrZone},
+				{Attribute: attrProjectID},
 			},
 			OrderBy: []discovery_kit_api.OrderBy{{Attribute: "steadybit.label", Direction: "ASC"}},
 		},
@@ -74,9 +80,9 @@ func (d *diskDiscovery) DescribeTarget() discovery_kit_api.TargetDescription {
 func (d *diskDiscovery) DescribeAttributes() []discovery_kit_api.AttributeDescription {
 	return []discovery_kit_api.AttributeDescription{
 		{Attribute: "gcp.persistent-disk.name", Label: discovery_kit_api.PluralLabel{One: "Disk name", Other: "Disk names"}},
-		{Attribute: "gcp.persistent-disk.type", Label: discovery_kit_api.PluralLabel{One: "Disk type", Other: "Disk types"}},
-		{Attribute: "gcp.persistent-disk.size-gb", Label: discovery_kit_api.PluralLabel{One: "Disk size (GiB)", Other: "Disk sizes (GiB)"}},
-		{Attribute: "gcp.persistent-disk.zone", Label: discovery_kit_api.PluralLabel{One: "Disk zone", Other: "Disk zones"}},
+		{Attribute: attrType, Label: discovery_kit_api.PluralLabel{One: "Disk type", Other: "Disk types"}},
+		{Attribute: attrSizeGB, Label: discovery_kit_api.PluralLabel{One: "Disk size (GiB)", Other: "Disk sizes (GiB)"}},
+		{Attribute: attrZone, Label: discovery_kit_api.PluralLabel{One: "Disk zone", Other: "Disk zones"}},
 		{Attribute: "gcp.persistent-disk.region", Label: discovery_kit_api.PluralLabel{One: "Disk region", Other: "Disk regions"}},
 		{Attribute: "gcp.persistent-disk.status", Label: discovery_kit_api.PluralLabel{One: "Disk status", Other: "Disk statuses"}},
 		{Attribute: "gcp.persistent-disk.users", Label: discovery_kit_api.PluralLabel{One: "Disk attached VM", Other: "Disk attached VMs"}},
@@ -87,7 +93,7 @@ func (d *diskDiscovery) DescribeAttributes() []discovery_kit_api.AttributeDescri
 		{Attribute: "gcp.persistent-disk.provisioned-iops", Label: discovery_kit_api.PluralLabel{One: "Disk provisioned IOPS", Other: "Disk provisioned IOPS"}},
 		{Attribute: "gcp.persistent-disk.provisioned-throughput", Label: discovery_kit_api.PluralLabel{One: "Disk provisioned throughput", Other: "Disk provisioned throughputs"}},
 		{Attribute: "gcp.persistent-disk.architecture", Label: discovery_kit_api.PluralLabel{One: "Disk architecture", Other: "Disk architectures"}},
-		{Attribute: "gcp.project.id", Label: discovery_kit_api.PluralLabel{One: "GCP project ID", Other: "GCP project IDs"}},
+		{Attribute: attrProjectID, Label: discovery_kit_api.PluralLabel{One: "GCP project ID", Other: "GCP project IDs"}},
 	}
 }
 
@@ -137,10 +143,10 @@ func classifyScope(key string) (zone, region string) {
 
 func toDiskTarget(disk *computepb.Disk, zone, region, projectID string) discovery_kit_api.Target {
 	attributes := make(map[string][]string)
-	attributes["gcp.project.id"] = []string{projectID}
+	attributes[attrProjectID] = []string{projectID}
 	attributes["gcp.persistent-disk.name"] = []string{disk.GetName()}
 	if zone != "" {
-		attributes["gcp.persistent-disk.zone"] = []string{zone}
+		attributes[attrZone] = []string{zone}
 	}
 	if region != "" {
 		attributes["gcp.persistent-disk.region"] = []string{region}
@@ -148,13 +154,13 @@ func toDiskTarget(disk *computepb.Disk, zone, region, projectID string) discover
 	if t := disk.GetType(); t != "" {
 		// type is a URL; surface the last path component for readability.
 		if i := strings.LastIndex(t, "/"); i >= 0 {
-			attributes["gcp.persistent-disk.type"] = []string{t[i+1:]}
+			attributes[attrType] = []string{t[i+1:]}
 		} else {
-			attributes["gcp.persistent-disk.type"] = []string{t}
+			attributes[attrType] = []string{t}
 		}
 	}
 	if v := disk.GetSizeGb(); v > 0 {
-		attributes["gcp.persistent-disk.size-gb"] = []string{strconv.Itoa(int(v))}
+		attributes[attrSizeGB] = []string{strconv.Itoa(int(v))}
 	}
 	if v := disk.GetStatus(); v != "" {
 		attributes["gcp.persistent-disk.status"] = []string{v}

--- a/extgke/cluster_discovery.go
+++ b/extgke/cluster_discovery.go
@@ -47,23 +47,23 @@ var gkeEnrichmentTargetTypes = []string{
 // gkeEnrichmentAttributes are stable, reliability-relevant config attributes copied onto matching
 // Kubernetes targets. No labels (high cardinality), no volatile status.
 var gkeEnrichmentAttributes = []discovery_kit_api.Attribute{
-	{Matcher: discovery_kit_api.Equals, Name: "gcp.project.id"},
-	{Matcher: discovery_kit_api.Equals, Name: "gcp.gke.cluster.name"},
-	{Matcher: discovery_kit_api.Equals, Name: "gcp.gke.cluster.location"},
-	{Matcher: discovery_kit_api.Equals, Name: "gcp.gke.cluster.location-type"},
-	{Matcher: discovery_kit_api.Equals, Name: "gcp.gke.cluster.kubernetes-version"},
-	{Matcher: discovery_kit_api.Equals, Name: "gcp.gke.cluster.release-channel"},
-	{Matcher: discovery_kit_api.Equals, Name: "gcp.gke.cluster.private-cluster"},
-	{Matcher: discovery_kit_api.Equals, Name: "gcp.gke.cluster.master-authorized-networks-enabled"},
-	{Matcher: discovery_kit_api.Equals, Name: "gcp.gke.cluster.master-authorized-networks-cidrs"},
-	{Matcher: discovery_kit_api.Equals, Name: "gcp.gke.cluster.api-server-open-to-internet"},
-	{Matcher: discovery_kit_api.Equals, Name: "gcp.gke.cluster.network"},
-	{Matcher: discovery_kit_api.Equals, Name: "gcp.gke.cluster.subnetwork"},
-	{Matcher: discovery_kit_api.Equals, Name: "gcp.gke.cluster.workload-identity-enabled"},
-	{Matcher: discovery_kit_api.Equals, Name: "gcp.gke.cluster.shielded-nodes-enabled"},
-	{Matcher: discovery_kit_api.Equals, Name: "gcp.gke.cluster.binary-authorization-evaluation-mode"},
-	{Matcher: discovery_kit_api.Equals, Name: "gcp.gke.cluster.logging-service"},
-	{Matcher: discovery_kit_api.Equals, Name: "gcp.gke.cluster.monitoring-service"},
+	{Matcher: discovery_kit_api.Equals, Name: attrProjectID},
+	{Matcher: discovery_kit_api.Equals, Name: attrClusterName},
+	{Matcher: discovery_kit_api.Equals, Name: attrClusterLocation},
+	{Matcher: discovery_kit_api.Equals, Name: attrClusterLocationType},
+	{Matcher: discovery_kit_api.Equals, Name: attrClusterKubernetesVersion},
+	{Matcher: discovery_kit_api.Equals, Name: attrClusterReleaseChannel},
+	{Matcher: discovery_kit_api.Equals, Name: attrClusterPrivateCluster},
+	{Matcher: discovery_kit_api.Equals, Name: attrClusterMasterAuthorizedNetsEnabled},
+	{Matcher: discovery_kit_api.Equals, Name: attrClusterMasterAuthorizedNetsCidrs},
+	{Matcher: discovery_kit_api.Equals, Name: attrClusterApiServerOpenToInternet},
+	{Matcher: discovery_kit_api.Equals, Name: attrClusterNetwork},
+	{Matcher: discovery_kit_api.Equals, Name: attrClusterSubnetwork},
+	{Matcher: discovery_kit_api.Equals, Name: attrClusterWorkloadIdentityEnabled},
+	{Matcher: discovery_kit_api.Equals, Name: attrClusterShieldedNodesEnabled},
+	{Matcher: discovery_kit_api.Equals, Name: attrClusterBinaryAuthEvalMode},
+	{Matcher: discovery_kit_api.Equals, Name: attrClusterLoggingService},
+	{Matcher: discovery_kit_api.Equals, Name: attrClusterMonitoringService},
 }
 
 func NewClusterDiscovery() discovery_kit_sdk.TargetDiscovery {
@@ -92,9 +92,9 @@ func (d *clusterDiscovery) DescribeTarget() discovery_kit_api.TargetDescription 
 		Table: discovery_kit_api.Table{
 			Columns: []discovery_kit_api.Column{
 				{Attribute: "steadybit.label"},
-				{Attribute: "gcp.gke.cluster.kubernetes-version"},
-				{Attribute: "gcp.gke.cluster.location"},
-				{Attribute: "gcp.project.id"},
+				{Attribute: attrClusterKubernetesVersion},
+				{Attribute: attrClusterLocation},
+				{Attribute: attrProjectID},
 			},
 			OrderBy: []discovery_kit_api.OrderBy{{Attribute: "steadybit.label", Direction: "ASC"}},
 		},
@@ -103,26 +103,26 @@ func (d *clusterDiscovery) DescribeTarget() discovery_kit_api.TargetDescription 
 
 func (d *clusterDiscovery) DescribeAttributes() []discovery_kit_api.AttributeDescription {
 	return []discovery_kit_api.AttributeDescription{
-		{Attribute: "gcp.gke.cluster.name", Label: discovery_kit_api.PluralLabel{One: "GKE cluster name", Other: "GKE cluster names"}},
-		{Attribute: "gcp.gke.cluster.location", Label: discovery_kit_api.PluralLabel{One: "GKE cluster location", Other: "GKE cluster locations"}},
-		{Attribute: "gcp.gke.cluster.location-type", Label: discovery_kit_api.PluralLabel{One: "GKE cluster location type", Other: "GKE cluster location types"}},
-		{Attribute: "gcp.gke.cluster.kubernetes-version", Label: discovery_kit_api.PluralLabel{One: "GKE Kubernetes version", Other: "GKE Kubernetes versions"}},
-		{Attribute: "gcp.gke.cluster.release-channel", Label: discovery_kit_api.PluralLabel{One: "GKE release channel", Other: "GKE release channels"}},
+		{Attribute: attrClusterName, Label: discovery_kit_api.PluralLabel{One: "GKE cluster name", Other: "GKE cluster names"}},
+		{Attribute: attrClusterLocation, Label: discovery_kit_api.PluralLabel{One: "GKE cluster location", Other: "GKE cluster locations"}},
+		{Attribute: attrClusterLocationType, Label: discovery_kit_api.PluralLabel{One: "GKE cluster location type", Other: "GKE cluster location types"}},
+		{Attribute: attrClusterKubernetesVersion, Label: discovery_kit_api.PluralLabel{One: "GKE Kubernetes version", Other: "GKE Kubernetes versions"}},
+		{Attribute: attrClusterReleaseChannel, Label: discovery_kit_api.PluralLabel{One: "GKE release channel", Other: "GKE release channels"}},
 		{Attribute: "gcp.gke.cluster.status", Label: discovery_kit_api.PluralLabel{One: "GKE cluster status", Other: "GKE cluster statuses"}},
-		{Attribute: "gcp.gke.cluster.private-cluster", Label: discovery_kit_api.PluralLabel{One: "GKE private cluster", Other: "GKE private clusters"}},
-		{Attribute: "gcp.gke.cluster.master-authorized-networks-enabled", Label: discovery_kit_api.PluralLabel{One: "GKE master-authorized-networks", Other: "GKE master-authorized-networks"}},
-		{Attribute: "gcp.gke.cluster.master-authorized-networks-cidrs", Label: discovery_kit_api.PluralLabel{One: "GKE master-authorized network CIDR", Other: "GKE master-authorized network CIDRs"}},
-		{Attribute: "gcp.gke.cluster.api-server-open-to-internet", Label: discovery_kit_api.PluralLabel{One: "GKE API server open to internet", Other: "GKE API server open to internet"}},
-		{Attribute: "gcp.gke.cluster.network", Label: discovery_kit_api.PluralLabel{One: "GKE cluster network", Other: "GKE cluster networks"}},
-		{Attribute: "gcp.gke.cluster.subnetwork", Label: discovery_kit_api.PluralLabel{One: "GKE cluster subnetwork", Other: "GKE cluster subnetworks"}},
-		{Attribute: "gcp.gke.cluster.workload-identity-enabled", Label: discovery_kit_api.PluralLabel{One: "GKE Workload Identity", Other: "GKE Workload Identity"}},
-		{Attribute: "gcp.gke.cluster.shielded-nodes-enabled", Label: discovery_kit_api.PluralLabel{One: "GKE Shielded Nodes", Other: "GKE Shielded Nodes"}},
-		{Attribute: "gcp.gke.cluster.binary-authorization-evaluation-mode", Label: discovery_kit_api.PluralLabel{One: "GKE Binary Authorization mode", Other: "GKE Binary Authorization modes"}},
-		{Attribute: "gcp.gke.cluster.logging-service", Label: discovery_kit_api.PluralLabel{One: "GKE logging service", Other: "GKE logging services"}},
-		{Attribute: "gcp.gke.cluster.monitoring-service", Label: discovery_kit_api.PluralLabel{One: "GKE monitoring service", Other: "GKE monitoring services"}},
+		{Attribute: attrClusterPrivateCluster, Label: discovery_kit_api.PluralLabel{One: "GKE private cluster", Other: "GKE private clusters"}},
+		{Attribute: attrClusterMasterAuthorizedNetsEnabled, Label: discovery_kit_api.PluralLabel{One: "GKE master-authorized-networks", Other: "GKE master-authorized-networks"}},
+		{Attribute: attrClusterMasterAuthorizedNetsCidrs, Label: discovery_kit_api.PluralLabel{One: "GKE master-authorized network CIDR", Other: "GKE master-authorized network CIDRs"}},
+		{Attribute: attrClusterApiServerOpenToInternet, Label: discovery_kit_api.PluralLabel{One: "GKE API server open to internet", Other: "GKE API server open to internet"}},
+		{Attribute: attrClusterNetwork, Label: discovery_kit_api.PluralLabel{One: "GKE cluster network", Other: "GKE cluster networks"}},
+		{Attribute: attrClusterSubnetwork, Label: discovery_kit_api.PluralLabel{One: "GKE cluster subnetwork", Other: "GKE cluster subnetworks"}},
+		{Attribute: attrClusterWorkloadIdentityEnabled, Label: discovery_kit_api.PluralLabel{One: "GKE Workload Identity", Other: "GKE Workload Identity"}},
+		{Attribute: attrClusterShieldedNodesEnabled, Label: discovery_kit_api.PluralLabel{One: "GKE Shielded Nodes", Other: "GKE Shielded Nodes"}},
+		{Attribute: attrClusterBinaryAuthEvalMode, Label: discovery_kit_api.PluralLabel{One: "GKE Binary Authorization mode", Other: "GKE Binary Authorization modes"}},
+		{Attribute: attrClusterLoggingService, Label: discovery_kit_api.PluralLabel{One: "GKE logging service", Other: "GKE logging services"}},
+		{Attribute: attrClusterMonitoringService, Label: discovery_kit_api.PluralLabel{One: "GKE monitoring service", Other: "GKE monitoring services"}},
 		{Attribute: "gcp.gke.cluster.node-locations", Label: discovery_kit_api.PluralLabel{One: "GKE node location", Other: "GKE node locations"}},
-		{Attribute: "gcp.project.id", Label: discovery_kit_api.PluralLabel{One: "GCP project ID", Other: "GCP project IDs"}},
-		{Attribute: "k8s.cluster-name", Label: discovery_kit_api.PluralLabel{One: "Kubernetes cluster name", Other: "Kubernetes cluster names"}},
+		{Attribute: attrProjectID, Label: discovery_kit_api.PluralLabel{One: "GCP project ID", Other: "GCP project IDs"}},
+		{Attribute: attrK8sClusterName, Label: discovery_kit_api.PluralLabel{One: "Kubernetes cluster name", Other: "Kubernetes cluster names"}},
 	}
 }
 
@@ -159,35 +159,35 @@ type clusterManagerApi interface {
 
 func toClusterTarget(c *containerpb.Cluster, projectID string) discovery_kit_api.Target {
 	attributes := make(map[string][]string)
-	attributes["gcp.project.id"] = []string{projectID}
-	attributes["gcp.gke.cluster.name"] = []string{c.Name}
-	attributes["gcp.gke.cluster.location"] = []string{c.Location}
-	attributes["gcp.gke.cluster.location-type"] = []string{classifyLocation(c.Location)}
+	attributes[attrProjectID] = []string{projectID}
+	attributes[attrClusterName] = []string{c.Name}
+	attributes[attrClusterLocation] = []string{c.Location}
+	attributes[attrClusterLocationType] = []string{classifyLocation(c.Location)}
 
 	// k8s.cluster-name = GKE cluster name (1:1 within a project; the extension-kubernetes discovery uses
 	// the kubeconfig context, which for GKE is the cluster name unless explicitly overridden).
-	attributes["k8s.cluster-name"] = []string{c.Name}
+	attributes[attrK8sClusterName] = []string{c.Name}
 
 	if c.CurrentMasterVersion != "" {
-		attributes["gcp.gke.cluster.kubernetes-version"] = []string{c.CurrentMasterVersion}
+		attributes[attrClusterKubernetesVersion] = []string{c.CurrentMasterVersion}
 	}
 	if c.Status != containerpb.Cluster_STATUS_UNSPECIFIED {
 		attributes["gcp.gke.cluster.status"] = []string{c.Status.String()}
 	}
 	if c.ReleaseChannel != nil && c.ReleaseChannel.Channel != containerpb.ReleaseChannel_UNSPECIFIED {
-		attributes["gcp.gke.cluster.release-channel"] = []string{c.ReleaseChannel.Channel.String()}
+		attributes[attrClusterReleaseChannel] = []string{c.ReleaseChannel.Channel.String()}
 	}
 	if c.LoggingService != "" {
-		attributes["gcp.gke.cluster.logging-service"] = []string{c.LoggingService}
+		attributes[attrClusterLoggingService] = []string{c.LoggingService}
 	}
 	if c.MonitoringService != "" {
-		attributes["gcp.gke.cluster.monitoring-service"] = []string{c.MonitoringService}
+		attributes[attrClusterMonitoringService] = []string{c.MonitoringService}
 	}
 	if c.Network != "" {
-		attributes["gcp.gke.cluster.network"] = []string{c.Network}
+		attributes[attrClusterNetwork] = []string{c.Network}
 	}
 	if c.Subnetwork != "" {
-		attributes["gcp.gke.cluster.subnetwork"] = []string{c.Subnetwork}
+		attributes[attrClusterSubnetwork] = []string{c.Subnetwork}
 	}
 	if len(c.Locations) > 0 {
 		locs := append([]string(nil), c.Locations...)
@@ -200,7 +200,7 @@ func toClusterTarget(c *containerpb.Cluster, projectID string) discovery_kit_api
 	// and drives api-server-open-to-internet below.
 	privateNodes := c.PrivateClusterConfig != nil && c.PrivateClusterConfig.EnablePrivateNodes
 	privateEndpoint := c.PrivateClusterConfig != nil && c.PrivateClusterConfig.EnablePrivateEndpoint
-	attributes["gcp.gke.cluster.private-cluster"] = []string{strconv.FormatBool(privateNodes)}
+	attributes[attrClusterPrivateCluster] = []string{strconv.FormatBool(privateNodes)}
 
 	manEnabled := false
 	var manCidrs []string
@@ -212,23 +212,23 @@ func toClusterTarget(c *containerpb.Cluster, projectID string) discovery_kit_api
 			}
 		}
 	}
-	attributes["gcp.gke.cluster.master-authorized-networks-enabled"] = []string{strconv.FormatBool(manEnabled)}
+	attributes[attrClusterMasterAuthorizedNetsEnabled] = []string{strconv.FormatBool(manEnabled)}
 	if len(manCidrs) > 0 {
 		sort.Strings(manCidrs)
-		attributes["gcp.gke.cluster.master-authorized-networks-cidrs"] = manCidrs
+		attributes[attrClusterMasterAuthorizedNetsCidrs] = manCidrs
 	}
 	// True iff the API server is reachable from the public internet without IP restriction.
 	// Private endpoint => not internet-reachable. Public endpoint AND no authorized-networks restriction => open.
-	attributes["gcp.gke.cluster.api-server-open-to-internet"] = []string{strconv.FormatBool(!privateEndpoint && !manEnabled)}
+	attributes[attrClusterApiServerOpenToInternet] = []string{strconv.FormatBool(!privateEndpoint && !manEnabled)}
 
 	wiEnabled := c.WorkloadIdentityConfig != nil && c.WorkloadIdentityConfig.WorkloadPool != ""
-	attributes["gcp.gke.cluster.workload-identity-enabled"] = []string{strconv.FormatBool(wiEnabled)}
+	attributes[attrClusterWorkloadIdentityEnabled] = []string{strconv.FormatBool(wiEnabled)}
 
 	shielded := c.ShieldedNodes != nil && c.ShieldedNodes.Enabled
-	attributes["gcp.gke.cluster.shielded-nodes-enabled"] = []string{strconv.FormatBool(shielded)}
+	attributes[attrClusterShieldedNodesEnabled] = []string{strconv.FormatBool(shielded)}
 
 	if c.BinaryAuthorization != nil && c.BinaryAuthorization.EvaluationMode != containerpb.BinaryAuthorization_EVALUATION_MODE_UNSPECIFIED {
-		attributes["gcp.gke.cluster.binary-authorization-evaluation-mode"] = []string{c.BinaryAuthorization.EvaluationMode.String()}
+		attributes[attrClusterBinaryAuthEvalMode] = []string{c.BinaryAuthorization.EvaluationMode.String()}
 	}
 
 	for k, v := range c.ResourceLabels {
@@ -269,13 +269,13 @@ func gkeClusterToK8sEnrichmentRule(destTargetType string) discovery_kit_api.Targ
 		Src: discovery_kit_api.SourceOrDestination{
 			Type: TargetIDCluster,
 			Selector: map[string]string{
-				"k8s.cluster-name": "${dest.k8s.cluster-name}",
+				attrK8sClusterName: "${dest.k8s.cluster-name}",
 			},
 		},
 		Dest: discovery_kit_api.SourceOrDestination{
 			Type: destTargetType,
 			Selector: map[string]string{
-				"k8s.cluster-name": "${src.k8s.cluster-name}",
+				attrK8sClusterName: "${src.k8s.cluster-name}",
 			},
 		},
 		Attributes: gkeEnrichmentAttributes,

--- a/extgke/common.go
+++ b/extgke/common.go
@@ -9,4 +9,28 @@ const (
 	TargetIDNodePool                   = "com.steadybit.extension_gcp.gke.nodepool"
 	NodePoolTerminateInstancesActionId = "com.steadybit.extension_gcp.gke.nodepool.terminate-instances"
 	targetIcon                         = "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIj48cGF0aCBkPSJNMTIgMmwxMCA1djEwbC0xMCA1LTEwLTVWN2wxMC01eiIgZmlsbD0iY3VycmVudENvbG9yIi8+PC9zdmc+"
+
+	// Attribute names extracted per Sonar go:S1192. Shared across cluster,
+	// nodepool discovery, and the terminate-instances attack.
+	attrProjectID                          = "gcp.project.id"
+	attrK8sClusterName                     = "k8s.cluster-name"
+	attrClusterName                        = "gcp.gke.cluster.name"
+	attrClusterLocation                    = "gcp.gke.cluster.location"
+	attrClusterLocationType                = "gcp.gke.cluster.location-type"
+	attrClusterKubernetesVersion           = "gcp.gke.cluster.kubernetes-version"
+	attrClusterReleaseChannel              = "gcp.gke.cluster.release-channel"
+	attrClusterPrivateCluster              = "gcp.gke.cluster.private-cluster"
+	attrClusterMasterAuthorizedNetsEnabled = "gcp.gke.cluster.master-authorized-networks-enabled"
+	attrClusterMasterAuthorizedNetsCidrs   = "gcp.gke.cluster.master-authorized-networks-cidrs"
+	attrClusterApiServerOpenToInternet     = "gcp.gke.cluster.api-server-open-to-internet"
+	attrClusterNetwork                     = "gcp.gke.cluster.network"
+	attrClusterSubnetwork                  = "gcp.gke.cluster.subnetwork"
+	attrClusterWorkloadIdentityEnabled     = "gcp.gke.cluster.workload-identity-enabled"
+	attrClusterShieldedNodesEnabled        = "gcp.gke.cluster.shielded-nodes-enabled"
+	attrClusterBinaryAuthEvalMode          = "gcp.gke.cluster.binary-authorization-evaluation-mode"
+	attrClusterLoggingService              = "gcp.gke.cluster.logging-service"
+	attrClusterMonitoringService           = "gcp.gke.cluster.monitoring-service"
+	attrNodePoolKubernetesVersion          = "gcp.gke.nodepool.kubernetes-version"
+	attrNodePoolMachineType                = "gcp.gke.nodepool.machine-type"
+	attrNodePoolAutoscalingEnabled         = "gcp.gke.nodepool.autoscaling.enabled"
 )

--- a/extgke/nodepool_attack_terminate_instances.go
+++ b/extgke/nodepool_attack_terminate_instances.go
@@ -126,7 +126,7 @@ func (a *nodePoolTerminateInstancesAttack) Describe() action_kit_api.ActionDescr
 
 func (a *nodePoolTerminateInstancesAttack) Prepare(ctx context.Context, state *NodePoolTerminateInstancesState, request action_kit_api.PrepareActionRequestBody) (*action_kit_api.PrepareResult, error) {
 	state.ProjectID = mustHave(request.Target.Attributes, "gcp.project.id")
-	state.ClusterName = mustHave(request.Target.Attributes, "gcp.gke.cluster.name")
+	state.ClusterName = mustHave(request.Target.Attributes, attrClusterName)
 	state.NodePoolName = mustHave(request.Target.Attributes, "gcp.gke.nodepool.name")
 	state.Location = mustHave(request.Target.Attributes, "gcp.gke.cluster.location")
 	if state.ProjectID == "" || state.ClusterName == "" || state.NodePoolName == "" || state.Location == "" {

--- a/extgke/nodepool_discovery.go
+++ b/extgke/nodepool_discovery.go
@@ -55,10 +55,10 @@ func (d *nodePoolDiscovery) DescribeTarget() discovery_kit_api.TargetDescription
 		Table: discovery_kit_api.Table{
 			Columns: []discovery_kit_api.Column{
 				{Attribute: "steadybit.label"},
-				{Attribute: "gcp.gke.cluster.name"},
-				{Attribute: "gcp.gke.nodepool.kubernetes-version"},
-				{Attribute: "gcp.gke.nodepool.machine-type"},
-				{Attribute: "gcp.gke.nodepool.autoscaling.enabled"},
+				{Attribute: attrClusterName},
+				{Attribute: attrNodePoolKubernetesVersion},
+				{Attribute: attrNodePoolMachineType},
+				{Attribute: attrNodePoolAutoscalingEnabled},
 			},
 			OrderBy: []discovery_kit_api.OrderBy{{Attribute: "steadybit.label", Direction: "ASC"}},
 		},
@@ -67,18 +67,18 @@ func (d *nodePoolDiscovery) DescribeTarget() discovery_kit_api.TargetDescription
 
 func (d *nodePoolDiscovery) DescribeAttributes() []discovery_kit_api.AttributeDescription {
 	return []discovery_kit_api.AttributeDescription{
-		{Attribute: "gcp.gke.cluster.name", Label: discovery_kit_api.PluralLabel{One: "GKE cluster name", Other: "GKE cluster names"}},
+		{Attribute: attrClusterName, Label: discovery_kit_api.PluralLabel{One: "GKE cluster name", Other: "GKE cluster names"}},
 		{Attribute: "gcp.gke.cluster.location", Label: discovery_kit_api.PluralLabel{One: "GKE cluster location", Other: "GKE cluster locations"}},
 		{Attribute: "gcp.gke.nodepool.name", Label: discovery_kit_api.PluralLabel{One: "GKE node pool name", Other: "GKE node pool names"}},
-		{Attribute: "gcp.gke.nodepool.kubernetes-version", Label: discovery_kit_api.PluralLabel{One: "GKE node pool Kubernetes version", Other: "GKE node pool Kubernetes versions"}},
+		{Attribute: attrNodePoolKubernetesVersion, Label: discovery_kit_api.PluralLabel{One: "GKE node pool Kubernetes version", Other: "GKE node pool Kubernetes versions"}},
 		{Attribute: "gcp.gke.nodepool.status", Label: discovery_kit_api.PluralLabel{One: "GKE node pool status", Other: "GKE node pool statuses"}},
-		{Attribute: "gcp.gke.nodepool.machine-type", Label: discovery_kit_api.PluralLabel{One: "GKE node pool machine type", Other: "GKE node pool machine types"}},
+		{Attribute: attrNodePoolMachineType, Label: discovery_kit_api.PluralLabel{One: "GKE node pool machine type", Other: "GKE node pool machine types"}},
 		{Attribute: "gcp.gke.nodepool.disk-type", Label: discovery_kit_api.PluralLabel{One: "GKE node pool disk type", Other: "GKE node pool disk types"}},
 		{Attribute: "gcp.gke.nodepool.disk-size-gb", Label: discovery_kit_api.PluralLabel{One: "GKE node pool disk size (GiB)", Other: "GKE node pool disk sizes (GiB)"}},
 		{Attribute: "gcp.gke.nodepool.image-type", Label: discovery_kit_api.PluralLabel{One: "GKE node pool image type", Other: "GKE node pool image types"}},
 		{Attribute: "gcp.gke.nodepool.preemptible", Label: discovery_kit_api.PluralLabel{One: "GKE node pool preemptible", Other: "GKE node pool preemptible"}},
 		{Attribute: "gcp.gke.nodepool.spot", Label: discovery_kit_api.PluralLabel{One: "GKE node pool spot", Other: "GKE node pool spot"}},
-		{Attribute: "gcp.gke.nodepool.autoscaling.enabled", Label: discovery_kit_api.PluralLabel{One: "GKE node pool autoscaling", Other: "GKE node pool autoscaling"}},
+		{Attribute: attrNodePoolAutoscalingEnabled, Label: discovery_kit_api.PluralLabel{One: "GKE node pool autoscaling", Other: "GKE node pool autoscaling"}},
 		{Attribute: "gcp.gke.nodepool.autoscaling.min-node-count", Label: discovery_kit_api.PluralLabel{One: "GKE node pool min node count", Other: "GKE node pool min node counts"}},
 		{Attribute: "gcp.gke.nodepool.autoscaling.max-node-count", Label: discovery_kit_api.PluralLabel{One: "GKE node pool max node count", Other: "GKE node pool max node counts"}},
 		{Attribute: "gcp.gke.nodepool.locations", Label: discovery_kit_api.PluralLabel{One: "GKE node pool location", Other: "GKE node pool locations"}},
@@ -130,20 +130,20 @@ func getAllNodePools(ctx context.Context, client clusterManagerApi, projectID st
 func toNodePoolTarget(np *containerpb.NodePool, cluster *containerpb.Cluster, projectID string) discovery_kit_api.Target {
 	attributes := make(map[string][]string)
 	attributes["gcp.project.id"] = []string{projectID}
-	attributes["gcp.gke.cluster.name"] = []string{cluster.Name}
+	attributes[attrClusterName] = []string{cluster.Name}
 	attributes["gcp.gke.cluster.location"] = []string{cluster.Location}
 	attributes["k8s.cluster-name"] = []string{cluster.Name}
 	attributes["gcp.gke.nodepool.name"] = []string{np.Name}
 
 	if np.Version != "" {
-		attributes["gcp.gke.nodepool.kubernetes-version"] = []string{np.Version}
+		attributes[attrNodePoolKubernetesVersion] = []string{np.Version}
 	}
 	if np.Status != containerpb.NodePool_STATUS_UNSPECIFIED {
 		attributes["gcp.gke.nodepool.status"] = []string{np.Status.String()}
 	}
 	if np.Config != nil {
 		if np.Config.MachineType != "" {
-			attributes["gcp.gke.nodepool.machine-type"] = []string{np.Config.MachineType}
+			attributes[attrNodePoolMachineType] = []string{np.Config.MachineType}
 		}
 		if np.Config.DiskType != "" {
 			attributes["gcp.gke.nodepool.disk-type"] = []string{np.Config.DiskType}
@@ -158,7 +158,7 @@ func toNodePoolTarget(np *containerpb.NodePool, cluster *containerpb.Cluster, pr
 		attributes["gcp.gke.nodepool.spot"] = []string{strconv.FormatBool(np.Config.Spot)}
 	}
 	asEnabled := np.Autoscaling != nil && np.Autoscaling.Enabled
-	attributes["gcp.gke.nodepool.autoscaling.enabled"] = []string{strconv.FormatBool(asEnabled)}
+	attributes[attrNodePoolAutoscalingEnabled] = []string{strconv.FormatBool(asEnabled)}
 	if asEnabled {
 		attributes["gcp.gke.nodepool.autoscaling.min-node-count"] = []string{strconv.Itoa(int(np.Autoscaling.MinNodeCount))}
 		attributes["gcp.gke.nodepool.autoscaling.max-node-count"] = []string{strconv.Itoa(int(np.Autoscaling.MaxNodeCount))}

--- a/extmemorystore/common.go
+++ b/extmemorystore/common.go
@@ -8,4 +8,10 @@ const (
 	TargetIDRedisInstance = "com.steadybit.extension_gcp.memorystore.redis-instance"
 	RedisFailoverActionId = "com.steadybit.extension_gcp.memorystore.redis-instance.failover"
 	targetIcon            = "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIj48cGF0aCBkPSJNMTIgM2M0Ljk3IDAgOSAxLjM0IDkgM3YxMmMwIDEuNjYtNC4wMyAzLTkgM3MtOS0xLjM0LTktM1Y2YzAtMS42NiA0LjAzLTMgOS0zem0wIDJjLTMuOSAwLTcgLjg5LTcgMnMzLjEgMiA3IDIgNy0uODkgNy0yLTMuMS0yLTctMnoiIGZpbGw9ImN1cnJlbnRDb2xvciIvPjwvc3ZnPg=="
+
+	// Attribute names extracted per Sonar go:S1192.
+	attrTier         = "gcp.memorystore.tier"
+	attrRedisVersion = "gcp.memorystore.redis-version"
+	attrRegion       = "gcp.memorystore.region"
+	attrProjectID    = "gcp.project.id"
 )

--- a/extmemorystore/redis_attack_failover.go
+++ b/extmemorystore/redis_attack_failover.go
@@ -111,7 +111,7 @@ func (a *redisFailoverAttack) Prepare(_ context.Context, state *RedisFailoverSta
 	if state.ProjectID == "" || state.InstanceID == "" || region == "" {
 		return nil, extension_kit.ToError("Target is missing one of: gcp.project.id, gcp.memorystore.instance.id, gcp.memorystore.region", nil)
 	}
-	if tier := request.Target.Attributes["gcp.memorystore.tier"]; len(tier) == 0 || tier[0] != "STANDARD_HA" {
+	if tier := request.Target.Attributes[attrTier]; len(tier) == 0 || tier[0] != "STANDARD_HA" {
 		return nil, extension_kit.ToError(fmt.Sprintf("Memorystore instance %s is not STANDARD_HA; failover requires a high-availability instance", state.InstanceID), nil)
 	}
 	state.InstanceName = fmt.Sprintf("projects/%s/locations/%s/instances/%s", state.ProjectID, region, state.InstanceID)

--- a/extmemorystore/redis_discovery.go
+++ b/extmemorystore/redis_discovery.go
@@ -55,10 +55,10 @@ func (d *redisDiscovery) DescribeTarget() discovery_kit_api.TargetDescription {
 		Table: discovery_kit_api.Table{
 			Columns: []discovery_kit_api.Column{
 				{Attribute: "steadybit.label"},
-				{Attribute: "gcp.memorystore.tier"},
-				{Attribute: "gcp.memorystore.redis-version"},
-				{Attribute: "gcp.memorystore.region"},
-				{Attribute: "gcp.project.id"},
+				{Attribute: attrTier},
+				{Attribute: attrRedisVersion},
+				{Attribute: attrRegion},
+				{Attribute: attrProjectID},
 			},
 			OrderBy: []discovery_kit_api.OrderBy{{Attribute: "steadybit.label", Direction: "ASC"}},
 		},
@@ -68,9 +68,9 @@ func (d *redisDiscovery) DescribeTarget() discovery_kit_api.TargetDescription {
 func (d *redisDiscovery) DescribeAttributes() []discovery_kit_api.AttributeDescription {
 	return []discovery_kit_api.AttributeDescription{
 		{Attribute: "gcp.memorystore.instance.id", Label: discovery_kit_api.PluralLabel{One: "Memorystore instance ID", Other: "Memorystore instance IDs"}},
-		{Attribute: "gcp.memorystore.tier", Label: discovery_kit_api.PluralLabel{One: "Memorystore tier", Other: "Memorystore tiers"}},
-		{Attribute: "gcp.memorystore.redis-version", Label: discovery_kit_api.PluralLabel{One: "Memorystore Redis version", Other: "Memorystore Redis versions"}},
-		{Attribute: "gcp.memorystore.region", Label: discovery_kit_api.PluralLabel{One: "Memorystore region", Other: "Memorystore regions"}},
+		{Attribute: attrTier, Label: discovery_kit_api.PluralLabel{One: "Memorystore tier", Other: "Memorystore tiers"}},
+		{Attribute: attrRedisVersion, Label: discovery_kit_api.PluralLabel{One: "Memorystore Redis version", Other: "Memorystore Redis versions"}},
+		{Attribute: attrRegion, Label: discovery_kit_api.PluralLabel{One: "Memorystore region", Other: "Memorystore regions"}},
 		{Attribute: "gcp.memorystore.location-id", Label: discovery_kit_api.PluralLabel{One: "Memorystore location", Other: "Memorystore locations"}},
 		{Attribute: "gcp.memorystore.alternative-location-id", Label: discovery_kit_api.PluralLabel{One: "Memorystore alternative location", Other: "Memorystore alternative locations"}},
 		{Attribute: "gcp.memorystore.memory-size-gb", Label: discovery_kit_api.PluralLabel{One: "Memorystore memory size (GiB)", Other: "Memorystore memory sizes (GiB)"}},
@@ -82,7 +82,7 @@ func (d *redisDiscovery) DescribeAttributes() []discovery_kit_api.AttributeDescr
 		{Attribute: "gcp.memorystore.replica-count", Label: discovery_kit_api.PluralLabel{One: "Memorystore replica count", Other: "Memorystore replica counts"}},
 		{Attribute: "gcp.memorystore.persistence-mode", Label: discovery_kit_api.PluralLabel{One: "Memorystore persistence mode", Other: "Memorystore persistence modes"}},
 		{Attribute: "gcp.memorystore.authorized-network", Label: discovery_kit_api.PluralLabel{One: "Memorystore authorized network", Other: "Memorystore authorized networks"}},
-		{Attribute: "gcp.project.id", Label: discovery_kit_api.PluralLabel{One: "GCP project ID", Other: "GCP project IDs"}},
+		{Attribute: attrProjectID, Label: discovery_kit_api.PluralLabel{One: "GCP project ID", Other: "GCP project IDs"}},
 	}
 }
 
@@ -125,16 +125,16 @@ func toRedisTarget(inst *redispb.Instance, projectID string) discovery_kit_api.T
 	}
 
 	attributes := make(map[string][]string)
-	attributes["gcp.project.id"] = []string{projectID}
+	attributes[attrProjectID] = []string{projectID}
 	attributes["gcp.memorystore.instance.id"] = []string{instanceID}
 	if region != "" {
-		attributes["gcp.memorystore.region"] = []string{region}
+		attributes[attrRegion] = []string{region}
 	}
 	if inst.Tier != redispb.Instance_TIER_UNSPECIFIED {
-		attributes["gcp.memorystore.tier"] = []string{inst.Tier.String()}
+		attributes[attrTier] = []string{inst.Tier.String()}
 	}
 	if inst.RedisVersion != "" {
-		attributes["gcp.memorystore.redis-version"] = []string{inst.RedisVersion}
+		attributes[attrRedisVersion] = []string{inst.RedisVersion}
 	}
 	if inst.LocationId != "" {
 		attributes["gcp.memorystore.location-id"] = []string{inst.LocationId}

--- a/extmig/common.go
+++ b/extmig/common.go
@@ -8,4 +8,10 @@ const (
 	TargetIDMig                = "com.steadybit.extension_gcp.mig"
 	MigDeleteInstancesActionId = "com.steadybit.extension_gcp.mig.delete-instances"
 	targetIcon                 = "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIj48cGF0aCBkPSJNNCA0aDh2OEg0VjR6bTEyIDBoNHY0aC00VjR6TTE2IDEwaDR2NGgtNHYtNHptLTQgNGg4djZoLThWMTR6TTQgMTRoNnY2SDR2LTZ6IiBmaWxsPSJjdXJyZW50Q29sb3IiLz48L3N2Zz4="
+
+	// Attribute names extracted per Sonar go:S1192.
+	attrScope      = "gcp.mig.scope"
+	attrTargetSize = "gcp.mig.target-size"
+	attrLocation   = "gcp.mig.location"
+	attrProjectID  = "gcp.project.id"
 )

--- a/extmig/mig_discovery.go
+++ b/extmig/mig_discovery.go
@@ -55,10 +55,10 @@ func (d *migDiscovery) DescribeTarget() discovery_kit_api.TargetDescription {
 		Table: discovery_kit_api.Table{
 			Columns: []discovery_kit_api.Column{
 				{Attribute: "steadybit.label"},
-				{Attribute: "gcp.mig.scope"},
-				{Attribute: "gcp.mig.target-size"},
-				{Attribute: "gcp.mig.location"},
-				{Attribute: "gcp.project.id"},
+				{Attribute: attrScope},
+				{Attribute: attrTargetSize},
+				{Attribute: attrLocation},
+				{Attribute: attrProjectID},
 			},
 			OrderBy: []discovery_kit_api.OrderBy{{Attribute: "steadybit.label", Direction: "ASC"}},
 		},
@@ -68,9 +68,9 @@ func (d *migDiscovery) DescribeTarget() discovery_kit_api.TargetDescription {
 func (d *migDiscovery) DescribeAttributes() []discovery_kit_api.AttributeDescription {
 	return []discovery_kit_api.AttributeDescription{
 		{Attribute: "gcp.mig.name", Label: discovery_kit_api.PluralLabel{One: "MIG name", Other: "MIG names"}},
-		{Attribute: "gcp.mig.scope", Label: discovery_kit_api.PluralLabel{One: "MIG scope", Other: "MIG scopes"}},
-		{Attribute: "gcp.mig.location", Label: discovery_kit_api.PluralLabel{One: "MIG location", Other: "MIG locations"}},
-		{Attribute: "gcp.mig.target-size", Label: discovery_kit_api.PluralLabel{One: "MIG target size", Other: "MIG target sizes"}},
+		{Attribute: attrScope, Label: discovery_kit_api.PluralLabel{One: "MIG scope", Other: "MIG scopes"}},
+		{Attribute: attrLocation, Label: discovery_kit_api.PluralLabel{One: "MIG location", Other: "MIG locations"}},
+		{Attribute: attrTargetSize, Label: discovery_kit_api.PluralLabel{One: "MIG target size", Other: "MIG target sizes"}},
 		{Attribute: "gcp.mig.base-instance-name", Label: discovery_kit_api.PluralLabel{One: "MIG base instance name", Other: "MIG base instance names"}},
 		{Attribute: "gcp.mig.instance-template", Label: discovery_kit_api.PluralLabel{One: "MIG instance template", Other: "MIG instance templates"}},
 		{Attribute: "gcp.mig.distribution-policy.target-shape", Label: discovery_kit_api.PluralLabel{One: "MIG distribution shape", Other: "MIG distribution shapes"}},
@@ -80,7 +80,7 @@ func (d *migDiscovery) DescribeAttributes() []discovery_kit_api.AttributeDescrip
 		{Attribute: "gcp.mig.update-policy.replacement-method", Label: discovery_kit_api.PluralLabel{One: "MIG update replacement method", Other: "MIG update replacement methods"}},
 		{Attribute: "gcp.mig.update-policy.minimal-action", Label: discovery_kit_api.PluralLabel{One: "MIG update minimal action", Other: "MIG update minimal actions"}},
 		{Attribute: "gcp.mig.stateful-policy.configured", Label: discovery_kit_api.PluralLabel{One: "MIG stateful policy configured", Other: "MIG stateful policy configured"}},
-		{Attribute: "gcp.project.id", Label: discovery_kit_api.PluralLabel{One: "GCP project ID", Other: "GCP project IDs"}},
+		{Attribute: attrProjectID, Label: discovery_kit_api.PluralLabel{One: "GCP project ID", Other: "GCP project IDs"}},
 	}
 }
 
@@ -134,11 +134,11 @@ func parseScope(key string) (scope string, location string) {
 
 func toMigTarget(mig *computepb.InstanceGroupManager, scope, location, projectID string) discovery_kit_api.Target {
 	attributes := make(map[string][]string)
-	attributes["gcp.project.id"] = []string{projectID}
+	attributes[attrProjectID] = []string{projectID}
 	attributes["gcp.mig.name"] = []string{mig.GetName()}
-	attributes["gcp.mig.scope"] = []string{scope}
-	attributes["gcp.mig.location"] = []string{location}
-	attributes["gcp.mig.target-size"] = []string{strconv.Itoa(int(mig.GetTargetSize()))}
+	attributes[attrScope] = []string{scope}
+	attributes[attrLocation] = []string{location}
+	attributes[attrTargetSize] = []string{strconv.Itoa(int(mig.GetTargetSize()))}
 	if v := mig.GetBaseInstanceName(); v != "" {
 		attributes["gcp.mig.base-instance-name"] = []string{v}
 	}

--- a/extnat/common.go
+++ b/extnat/common.go
@@ -8,4 +8,10 @@ const (
 	TargetIDCloudNat             = "com.steadybit.extension_gcp.cloud-nat"
 	CloudNatDisassociateActionId = "com.steadybit.extension_gcp.cloud-nat.disassociate-subnets"
 	targetIcon                   = "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIj48cGF0aCBkPSJNMTIgMmw0IDRoLTN2NGgtMlY2SDhsNC00em0wIDIwbC00LTRoM3YtNGgyVjE4aDNsLTQgNHpNMiAxMmw0LTR2M2g0djJINlYxNmwtNC00em0yMCAwbC00IDR2LTNoLTR2LTJoNFY4bDQgNHoiIGZpbGw9ImN1cnJlbnRDb2xvciIvPjwvc3ZnPg=="
+
+	// Attribute names extracted per Sonar go:S1192.
+	attrRegion                   = "gcp.cloud-nat.region"
+	attrSourceSubnetworkIpRanges = "gcp.cloud-nat.source-subnetwork-ip-ranges"
+	attrSubnetworkCount          = "gcp.cloud-nat.subnetwork-count"
+	attrProjectID                = "gcp.project.id"
 )

--- a/extnat/nat_discovery.go
+++ b/extnat/nat_discovery.go
@@ -56,10 +56,10 @@ func (d *natDiscovery) DescribeTarget() discovery_kit_api.TargetDescription {
 		Table: discovery_kit_api.Table{
 			Columns: []discovery_kit_api.Column{
 				{Attribute: "steadybit.label"},
-				{Attribute: "gcp.cloud-nat.region"},
-				{Attribute: "gcp.cloud-nat.source-subnetwork-ip-ranges"},
-				{Attribute: "gcp.cloud-nat.subnetwork-count"},
-				{Attribute: "gcp.project.id"},
+				{Attribute: attrRegion},
+				{Attribute: attrSourceSubnetworkIpRanges},
+				{Attribute: attrSubnetworkCount},
+				{Attribute: attrProjectID},
 			},
 			OrderBy: []discovery_kit_api.OrderBy{{Attribute: "steadybit.label", Direction: "ASC"}},
 		},
@@ -71,17 +71,17 @@ func (d *natDiscovery) DescribeAttributes() []discovery_kit_api.AttributeDescrip
 		{Attribute: "gcp.cloud-nat.name", Label: discovery_kit_api.PluralLabel{One: "Cloud NAT name", Other: "Cloud NAT names"}},
 		{Attribute: "gcp.cloud-nat.router", Label: discovery_kit_api.PluralLabel{One: "Cloud NAT router", Other: "Cloud NAT routers"}},
 		{Attribute: "gcp.cloud-nat.network", Label: discovery_kit_api.PluralLabel{One: "Cloud NAT network", Other: "Cloud NAT networks"}},
-		{Attribute: "gcp.cloud-nat.region", Label: discovery_kit_api.PluralLabel{One: "Cloud NAT region", Other: "Cloud NAT regions"}},
-		{Attribute: "gcp.cloud-nat.source-subnetwork-ip-ranges", Label: discovery_kit_api.PluralLabel{One: "Cloud NAT source subnetwork IP ranges mode", Other: "Cloud NAT source subnetwork IP ranges modes"}},
+		{Attribute: attrRegion, Label: discovery_kit_api.PluralLabel{One: "Cloud NAT region", Other: "Cloud NAT regions"}},
+		{Attribute: attrSourceSubnetworkIpRanges, Label: discovery_kit_api.PluralLabel{One: "Cloud NAT source subnetwork IP ranges mode", Other: "Cloud NAT source subnetwork IP ranges modes"}},
 		{Attribute: "gcp.cloud-nat.nat-ip-allocate-option", Label: discovery_kit_api.PluralLabel{One: "Cloud NAT IP allocation option", Other: "Cloud NAT IP allocation options"}},
 		{Attribute: "gcp.cloud-nat.nat-ips", Label: discovery_kit_api.PluralLabel{One: "Cloud NAT IP", Other: "Cloud NAT IPs"}},
 		{Attribute: "gcp.cloud-nat.endpoint-types", Label: discovery_kit_api.PluralLabel{One: "Cloud NAT endpoint type", Other: "Cloud NAT endpoint types"}},
 		{Attribute: "gcp.cloud-nat.subnetworks", Label: discovery_kit_api.PluralLabel{One: "Cloud NAT subnetwork", Other: "Cloud NAT subnetworks"}},
-		{Attribute: "gcp.cloud-nat.subnetwork-count", Label: discovery_kit_api.PluralLabel{One: "Cloud NAT subnetwork count", Other: "Cloud NAT subnetwork counts"}},
+		{Attribute: attrSubnetworkCount, Label: discovery_kit_api.PluralLabel{One: "Cloud NAT subnetwork count", Other: "Cloud NAT subnetwork counts"}},
 		{Attribute: "gcp.cloud-nat.min-ports-per-vm", Label: discovery_kit_api.PluralLabel{One: "Cloud NAT min ports per VM", Other: "Cloud NAT min ports per VM"}},
 		{Attribute: "gcp.cloud-nat.log-config.enable", Label: discovery_kit_api.PluralLabel{One: "Cloud NAT logging", Other: "Cloud NAT logging"}},
 		{Attribute: "gcp.cloud-nat.enable-dynamic-port-allocation", Label: discovery_kit_api.PluralLabel{One: "Cloud NAT dynamic port allocation", Other: "Cloud NAT dynamic port allocation"}},
-		{Attribute: "gcp.project.id", Label: discovery_kit_api.PluralLabel{One: "GCP project ID", Other: "GCP project IDs"}},
+		{Attribute: attrProjectID, Label: discovery_kit_api.PluralLabel{One: "GCP project ID", Other: "GCP project IDs"}},
 	}
 }
 
@@ -123,15 +123,15 @@ func getAllNats(ctx context.Context, client *compute.RoutersClient, projectID st
 
 func toNatTarget(router *computepb.Router, nat *computepb.RouterNat, region, projectID string) discovery_kit_api.Target {
 	attributes := make(map[string][]string)
-	attributes["gcp.project.id"] = []string{projectID}
+	attributes[attrProjectID] = []string{projectID}
 	attributes["gcp.cloud-nat.name"] = []string{nat.GetName()}
 	attributes["gcp.cloud-nat.router"] = []string{router.GetName()}
-	attributes["gcp.cloud-nat.region"] = []string{region}
+	attributes[attrRegion] = []string{region}
 	if v := router.GetNetwork(); v != "" {
 		attributes["gcp.cloud-nat.network"] = []string{v}
 	}
 	if v := nat.GetSourceSubnetworkIpRangesToNat(); v != "" {
-		attributes["gcp.cloud-nat.source-subnetwork-ip-ranges"] = []string{v}
+		attributes[attrSourceSubnetworkIpRanges] = []string{v}
 	}
 	if v := nat.GetNatIpAllocateOption(); v != "" {
 		attributes["gcp.cloud-nat.nat-ip-allocate-option"] = []string{v}
@@ -157,7 +157,7 @@ func toNatTarget(router *computepb.Router, nat *computepb.RouterNat, region, pro
 	if len(subnetNames) > 0 {
 		attributes["gcp.cloud-nat.subnetworks"] = subnetNames
 	}
-	attributes["gcp.cloud-nat.subnetwork-count"] = []string{strconv.Itoa(len(subnets))}
+	attributes[attrSubnetworkCount] = []string{strconv.Itoa(len(subnets))}
 	if v := nat.GetMinPortsPerVm(); v != 0 {
 		attributes["gcp.cloud-nat.min-ports-per-vm"] = []string{strconv.Itoa(int(v))}
 	}

--- a/extpubsub/common.go
+++ b/extpubsub/common.go
@@ -8,4 +8,13 @@ const (
 	TargetIDTopic        = "com.steadybit.extension_gcp.pubsub.topic"
 	TargetIDSubscription = "com.steadybit.extension_gcp.pubsub.subscription"
 	targetIcon           = "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIj48cGF0aCBkPSJNNCA0aDE2djJINFY0em0wIDdoMTZ2Mkg0di0yem0wIDdoMTZ2Mkg0di0yeiIgZmlsbD0iY3VycmVudENvbG9yIi8+PC9zdmc+"
+
+	// Attribute names extracted per Sonar go:S1192. Shared across topic and
+	// subscription discovery files in this package.
+	attrProjectID                      = "gcp.project.id"
+	attrSubscriptionTopic              = "gcp.pubsub.subscription.topic"
+	attrSubscriptionDeliveryType       = "gcp.pubsub.subscription.delivery-type"
+	attrSubscriptionAckDeadlineSeconds = "gcp.pubsub.subscription.ack-deadline-seconds"
+	attrTopicMessageRetentionDuration  = "gcp.pubsub.topic.message-retention-duration"
+	attrTopicKmsKeyName                = "gcp.pubsub.topic.kms-key-name"
 )

--- a/extpubsub/subscription_discovery.go
+++ b/extpubsub/subscription_discovery.go
@@ -55,10 +55,10 @@ func (d *subscriptionDiscovery) DescribeTarget() discovery_kit_api.TargetDescrip
 		Table: discovery_kit_api.Table{
 			Columns: []discovery_kit_api.Column{
 				{Attribute: "steadybit.label"},
-				{Attribute: "gcp.pubsub.subscription.topic"},
-				{Attribute: "gcp.pubsub.subscription.delivery-type"},
-				{Attribute: "gcp.pubsub.subscription.ack-deadline-seconds"},
-				{Attribute: "gcp.project.id"},
+				{Attribute: attrSubscriptionTopic},
+				{Attribute: attrSubscriptionDeliveryType},
+				{Attribute: attrSubscriptionAckDeadlineSeconds},
+				{Attribute: attrProjectID},
 			},
 			OrderBy: []discovery_kit_api.OrderBy{{Attribute: "steadybit.label", Direction: "ASC"}},
 		},
@@ -68,9 +68,9 @@ func (d *subscriptionDiscovery) DescribeTarget() discovery_kit_api.TargetDescrip
 func (d *subscriptionDiscovery) DescribeAttributes() []discovery_kit_api.AttributeDescription {
 	return []discovery_kit_api.AttributeDescription{
 		{Attribute: "gcp.pubsub.subscription.name", Label: discovery_kit_api.PluralLabel{One: "Pub/Sub subscription name", Other: "Pub/Sub subscription names"}},
-		{Attribute: "gcp.pubsub.subscription.topic", Label: discovery_kit_api.PluralLabel{One: "Pub/Sub subscription topic", Other: "Pub/Sub subscription topics"}},
-		{Attribute: "gcp.pubsub.subscription.delivery-type", Label: discovery_kit_api.PluralLabel{One: "Pub/Sub subscription delivery type", Other: "Pub/Sub subscription delivery types"}},
-		{Attribute: "gcp.pubsub.subscription.ack-deadline-seconds", Label: discovery_kit_api.PluralLabel{One: "Pub/Sub subscription ack deadline", Other: "Pub/Sub subscription ack deadlines"}},
+		{Attribute: attrSubscriptionTopic, Label: discovery_kit_api.PluralLabel{One: "Pub/Sub subscription topic", Other: "Pub/Sub subscription topics"}},
+		{Attribute: attrSubscriptionDeliveryType, Label: discovery_kit_api.PluralLabel{One: "Pub/Sub subscription delivery type", Other: "Pub/Sub subscription delivery types"}},
+		{Attribute: attrSubscriptionAckDeadlineSeconds, Label: discovery_kit_api.PluralLabel{One: "Pub/Sub subscription ack deadline", Other: "Pub/Sub subscription ack deadlines"}},
 		{Attribute: "gcp.pubsub.subscription.message-retention-duration", Label: discovery_kit_api.PluralLabel{One: "Pub/Sub subscription message retention", Other: "Pub/Sub subscription message retentions"}},
 		{Attribute: "gcp.pubsub.subscription.retain-acked-messages", Label: discovery_kit_api.PluralLabel{One: "Pub/Sub subscription retain acked", Other: "Pub/Sub subscription retain acked"}},
 		{Attribute: "gcp.pubsub.subscription.enable-message-ordering", Label: discovery_kit_api.PluralLabel{One: "Pub/Sub subscription message ordering", Other: "Pub/Sub subscription message ordering"}},
@@ -84,7 +84,7 @@ func (d *subscriptionDiscovery) DescribeAttributes() []discovery_kit_api.Attribu
 		{Attribute: "gcp.pubsub.subscription.retry-policy.minimum-backoff", Label: discovery_kit_api.PluralLabel{One: "Pub/Sub subscription retry min backoff", Other: "Pub/Sub subscription retry min backoffs"}},
 		{Attribute: "gcp.pubsub.subscription.retry-policy.maximum-backoff", Label: discovery_kit_api.PluralLabel{One: "Pub/Sub subscription retry max backoff", Other: "Pub/Sub subscription retry max backoffs"}},
 		{Attribute: "gcp.pubsub.subscription.expiration-policy.ttl", Label: discovery_kit_api.PluralLabel{One: "Pub/Sub subscription expiration TTL", Other: "Pub/Sub subscription expiration TTLs"}},
-		{Attribute: "gcp.project.id", Label: discovery_kit_api.PluralLabel{One: "GCP project ID", Other: "GCP project IDs"}},
+		{Attribute: attrProjectID, Label: discovery_kit_api.PluralLabel{One: "GCP project ID", Other: "GCP project IDs"}},
 	}
 }
 
@@ -124,14 +124,14 @@ func toSubscriptionTarget(s *pubsubpb.Subscription, projectID string) discovery_
 	}
 
 	attributes := make(map[string][]string)
-	attributes["gcp.project.id"] = []string{projectID}
+	attributes[attrProjectID] = []string{projectID}
 	attributes["gcp.pubsub.subscription.name"] = []string{name}
 	if s.Topic != "" {
-		attributes["gcp.pubsub.subscription.topic"] = []string{s.Topic}
+		attributes[attrSubscriptionTopic] = []string{s.Topic}
 	}
-	attributes["gcp.pubsub.subscription.delivery-type"] = []string{deliveryType(s)}
+	attributes[attrSubscriptionDeliveryType] = []string{deliveryType(s)}
 	if s.AckDeadlineSeconds > 0 {
-		attributes["gcp.pubsub.subscription.ack-deadline-seconds"] = []string{strconv.Itoa(int(s.AckDeadlineSeconds))}
+		attributes[attrSubscriptionAckDeadlineSeconds] = []string{strconv.Itoa(int(s.AckDeadlineSeconds))}
 	}
 	if s.MessageRetentionDuration != nil {
 		attributes["gcp.pubsub.subscription.message-retention-duration"] = []string{s.MessageRetentionDuration.AsDuration().String()}

--- a/extpubsub/topic_discovery.go
+++ b/extpubsub/topic_discovery.go
@@ -55,9 +55,9 @@ func (d *topicDiscovery) DescribeTarget() discovery_kit_api.TargetDescription {
 		Table: discovery_kit_api.Table{
 			Columns: []discovery_kit_api.Column{
 				{Attribute: "steadybit.label"},
-				{Attribute: "gcp.pubsub.topic.message-retention-duration"},
-				{Attribute: "gcp.pubsub.topic.kms-key-name"},
-				{Attribute: "gcp.project.id"},
+				{Attribute: attrTopicMessageRetentionDuration},
+				{Attribute: attrTopicKmsKeyName},
+				{Attribute: attrProjectID},
 			},
 			OrderBy: []discovery_kit_api.OrderBy{{Attribute: "steadybit.label", Direction: "ASC"}},
 		},
@@ -67,15 +67,15 @@ func (d *topicDiscovery) DescribeTarget() discovery_kit_api.TargetDescription {
 func (d *topicDiscovery) DescribeAttributes() []discovery_kit_api.AttributeDescription {
 	return []discovery_kit_api.AttributeDescription{
 		{Attribute: "gcp.pubsub.topic.name", Label: discovery_kit_api.PluralLabel{One: "Pub/Sub topic name", Other: "Pub/Sub topic names"}},
-		{Attribute: "gcp.pubsub.topic.message-retention-duration", Label: discovery_kit_api.PluralLabel{One: "Pub/Sub topic message retention", Other: "Pub/Sub topic message retentions"}},
-		{Attribute: "gcp.pubsub.topic.kms-key-name", Label: discovery_kit_api.PluralLabel{One: "Pub/Sub topic KMS key", Other: "Pub/Sub topic KMS keys"}},
+		{Attribute: attrTopicMessageRetentionDuration, Label: discovery_kit_api.PluralLabel{One: "Pub/Sub topic message retention", Other: "Pub/Sub topic message retentions"}},
+		{Attribute: attrTopicKmsKeyName, Label: discovery_kit_api.PluralLabel{One: "Pub/Sub topic KMS key", Other: "Pub/Sub topic KMS keys"}},
 		{Attribute: "gcp.pubsub.topic.message-storage-policy.allowed-persistence-regions", Label: discovery_kit_api.PluralLabel{One: "Pub/Sub topic allowed region", Other: "Pub/Sub topic allowed regions"}},
 		{Attribute: "gcp.pubsub.topic.message-storage-policy.enforce-in-transit", Label: discovery_kit_api.PluralLabel{One: "Pub/Sub topic enforce in-transit", Other: "Pub/Sub topic enforce in-transit"}},
 		{Attribute: "gcp.pubsub.topic.schema-settings.schema", Label: discovery_kit_api.PluralLabel{One: "Pub/Sub topic schema", Other: "Pub/Sub topic schemas"}},
 		{Attribute: "gcp.pubsub.topic.schema-settings.encoding", Label: discovery_kit_api.PluralLabel{One: "Pub/Sub topic schema encoding", Other: "Pub/Sub topic schema encodings"}},
 		{Attribute: "gcp.pubsub.topic.state", Label: discovery_kit_api.PluralLabel{One: "Pub/Sub topic state", Other: "Pub/Sub topic states"}},
 		{Attribute: "gcp.pubsub.topic.satisfies-pzs", Label: discovery_kit_api.PluralLabel{One: "Pub/Sub topic PZS compliance", Other: "Pub/Sub topic PZS compliance"}},
-		{Attribute: "gcp.project.id", Label: discovery_kit_api.PluralLabel{One: "GCP project ID", Other: "GCP project IDs"}},
+		{Attribute: attrProjectID, Label: discovery_kit_api.PluralLabel{One: "GCP project ID", Other: "GCP project IDs"}},
 	}
 }
 
@@ -115,13 +115,13 @@ func toTopicTarget(t *pubsubpb.Topic, projectID string) discovery_kit_api.Target
 	}
 
 	attributes := make(map[string][]string)
-	attributes["gcp.project.id"] = []string{projectID}
+	attributes[attrProjectID] = []string{projectID}
 	attributes["gcp.pubsub.topic.name"] = []string{name}
 	if t.MessageRetentionDuration != nil {
-		attributes["gcp.pubsub.topic.message-retention-duration"] = []string{t.MessageRetentionDuration.AsDuration().String()}
+		attributes[attrTopicMessageRetentionDuration] = []string{t.MessageRetentionDuration.AsDuration().String()}
 	}
 	if t.KmsKeyName != "" {
-		attributes["gcp.pubsub.topic.kms-key-name"] = []string{t.KmsKeyName}
+		attributes[attrTopicKmsKeyName] = []string{t.KmsKeyName}
 	}
 	if t.MessageStoragePolicy != nil {
 		if len(t.MessageStoragePolicy.AllowedPersistenceRegions) > 0 {

--- a/extspanner/common.go
+++ b/extspanner/common.go
@@ -7,4 +7,10 @@ package extspanner
 const (
 	TargetIDInstance = "com.steadybit.extension_gcp.spanner.instance"
 	targetIcon       = "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIj48cGF0aCBkPSJNNCA0aDE2djJINFY0em0wIDdoMTZ2Mkg0di0yem0wIDdoMTZ2Mkg0di0yeiIgZmlsbD0iY3VycmVudENvbG9yIi8+PC9zdmc+"
+
+	// Attribute names extracted per Sonar go:S1192.
+	attrConfig          = "gcp.spanner.instance.config"
+	attrEdition         = "gcp.spanner.instance.edition"
+	attrProcessingUnits = "gcp.spanner.instance.processing-units"
+	attrProjectID       = "gcp.project.id"
 )

--- a/extspanner/instance_discovery.go
+++ b/extspanner/instance_discovery.go
@@ -55,10 +55,10 @@ func (d *instanceDiscovery) DescribeTarget() discovery_kit_api.TargetDescription
 		Table: discovery_kit_api.Table{
 			Columns: []discovery_kit_api.Column{
 				{Attribute: "steadybit.label"},
-				{Attribute: "gcp.spanner.instance.config"},
-				{Attribute: "gcp.spanner.instance.edition"},
-				{Attribute: "gcp.spanner.instance.processing-units"},
-				{Attribute: "gcp.project.id"},
+				{Attribute: attrConfig},
+				{Attribute: attrEdition},
+				{Attribute: attrProcessingUnits},
+				{Attribute: attrProjectID},
 			},
 			OrderBy: []discovery_kit_api.OrderBy{{Attribute: "steadybit.label", Direction: "ASC"}},
 		},
@@ -69,15 +69,15 @@ func (d *instanceDiscovery) DescribeAttributes() []discovery_kit_api.AttributeDe
 	return []discovery_kit_api.AttributeDescription{
 		{Attribute: "gcp.spanner.instance.name", Label: discovery_kit_api.PluralLabel{One: "Spanner instance name", Other: "Spanner instance names"}},
 		{Attribute: "gcp.spanner.instance.display-name", Label: discovery_kit_api.PluralLabel{One: "Spanner instance display name", Other: "Spanner instance display names"}},
-		{Attribute: "gcp.spanner.instance.config", Label: discovery_kit_api.PluralLabel{One: "Spanner instance config", Other: "Spanner instance configs"}},
-		{Attribute: "gcp.spanner.instance.edition", Label: discovery_kit_api.PluralLabel{One: "Spanner instance edition", Other: "Spanner instance editions"}},
+		{Attribute: attrConfig, Label: discovery_kit_api.PluralLabel{One: "Spanner instance config", Other: "Spanner instance configs"}},
+		{Attribute: attrEdition, Label: discovery_kit_api.PluralLabel{One: "Spanner instance edition", Other: "Spanner instance editions"}},
 		{Attribute: "gcp.spanner.instance.type", Label: discovery_kit_api.PluralLabel{One: "Spanner instance type", Other: "Spanner instance types"}},
 		{Attribute: "gcp.spanner.instance.state", Label: discovery_kit_api.PluralLabel{One: "Spanner instance state", Other: "Spanner instance states"}},
 		{Attribute: "gcp.spanner.instance.node-count", Label: discovery_kit_api.PluralLabel{One: "Spanner instance node count", Other: "Spanner instance node counts"}},
-		{Attribute: "gcp.spanner.instance.processing-units", Label: discovery_kit_api.PluralLabel{One: "Spanner instance processing units", Other: "Spanner instance processing units"}},
+		{Attribute: attrProcessingUnits, Label: discovery_kit_api.PluralLabel{One: "Spanner instance processing units", Other: "Spanner instance processing units"}},
 		{Attribute: "gcp.spanner.instance.autoscaling.configured", Label: discovery_kit_api.PluralLabel{One: "Spanner instance autoscaling configured", Other: "Spanner instance autoscaling configured"}},
 		{Attribute: "gcp.spanner.instance.default-backup-schedule-type", Label: discovery_kit_api.PluralLabel{One: "Spanner default backup schedule", Other: "Spanner default backup schedules"}},
-		{Attribute: "gcp.project.id", Label: discovery_kit_api.PluralLabel{One: "GCP project ID", Other: "GCP project IDs"}},
+		{Attribute: attrProjectID, Label: discovery_kit_api.PluralLabel{One: "GCP project ID", Other: "GCP project IDs"}},
 	}
 }
 
@@ -122,16 +122,16 @@ func toInstanceTarget(inst *instancepb.Instance, projectID string) discovery_kit
 	}
 
 	attributes := make(map[string][]string)
-	attributes["gcp.project.id"] = []string{projectID}
+	attributes[attrProjectID] = []string{projectID}
 	attributes["gcp.spanner.instance.name"] = []string{name}
 	if inst.DisplayName != "" {
 		attributes["gcp.spanner.instance.display-name"] = []string{inst.DisplayName}
 	}
 	if configName != "" {
-		attributes["gcp.spanner.instance.config"] = []string{configName}
+		attributes[attrConfig] = []string{configName}
 	}
 	if inst.Edition != instancepb.Instance_EDITION_UNSPECIFIED {
-		attributes["gcp.spanner.instance.edition"] = []string{inst.Edition.String()}
+		attributes[attrEdition] = []string{inst.Edition.String()}
 	}
 	if inst.InstanceType != instancepb.Instance_INSTANCE_TYPE_UNSPECIFIED {
 		attributes["gcp.spanner.instance.type"] = []string{inst.InstanceType.String()}
@@ -143,7 +143,7 @@ func toInstanceTarget(inst *instancepb.Instance, projectID string) discovery_kit
 		attributes["gcp.spanner.instance.node-count"] = []string{strconv.Itoa(int(inst.NodeCount))}
 	}
 	if inst.ProcessingUnits > 0 {
-		attributes["gcp.spanner.instance.processing-units"] = []string{strconv.Itoa(int(inst.ProcessingUnits))}
+		attributes[attrProcessingUnits] = []string{strconv.Itoa(int(inst.ProcessingUnits))}
 	}
 	attributes["gcp.spanner.instance.autoscaling.configured"] = []string{strconv.FormatBool(inst.AutoscalingConfig != nil)}
 	if inst.DefaultBackupScheduleType != instancepb.Instance_DEFAULT_BACKUP_SCHEDULE_TYPE_UNSPECIFIED {


### PR DESCRIPTION
## Summary

Fixes the 66 \`go:S1192\` duplicate-literal issues Sonar flagged on \`main\` after #334 landed. Each of the 10 new discovery files repeated the same attribute names 3-4 times — extract each set into a per-package const block colocated with the existing \`TargetID\` / \`actionId\` / \`targetIcon\` constants.

Also swaps two attack-file usages (\`nodepool_attack_terminate_instances\`, \`redis_attack_failover\`) to the same constants for consistency — they weren't individually flagged (below the 3-use threshold in each attack file) but reading a constant instead of a raw literal makes them robust to future renames.

Kills 56 of 90 open Sonar issues on \`main\`. The remaining 34 are:
- 10 \`go:S3776\` cognitive-complexity refactors → follow-up batch B
- 14 pre-existing Docker + shell-script lints (\`Dockerfile\`, \`linuxpkg/scripts/*.sh\`) — not touched here since they're scaffold boilerplate present in every extension repo
- 10 \`go:S1192\` in \`extvm/vm_discovery.go\` — pre-existing file, not from #334, out of scope for this batch

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [x] All existing unit tests pass (no test files exist for the new packages yet — those come with the attack test coverage)
- [x] Grep confirms each extracted literal now appears exactly once in source (the const declaration)