### PR TITLE
cleanup: reduce cognitive complexity below 15 (Sonar go:S3776)

### DIFF
--- a/extcloudrun/service_discovery.go
+++ b/extcloudrun/service_discovery.go
@@ -7,7 +7,6 @@ package extcloudrun
 import (
 	"context"
 	"fmt"
-	"strconv"
 	"strings"
 	"time"
 
@@ -120,46 +119,18 @@ func toServiceTarget(s *runpb.Service, projectID string) discovery_kit_api.Targe
 	attributes := make(map[string][]string)
 	attributes[attrProjectID] = []string{projectID}
 	attributes["gcp.cloudrun.service.name"] = []string{name}
-	if location != "" {
-		attributes[attrLocation] = []string{location}
-	}
+	utils.SetStr(attributes, attrLocation, location)
 	if s.Ingress != runpb.IngressTraffic_INGRESS_TRAFFIC_UNSPECIFIED {
 		attributes[attrIngress] = []string{s.Ingress.String()}
 	}
 	if s.LaunchStage != 0 {
 		attributes["gcp.cloudrun.service.launch-stage"] = []string{s.LaunchStage.String()}
 	}
-	attributes["gcp.cloudrun.service.invoker-iam-disabled"] = []string{strconv.FormatBool(s.InvokerIamDisabled)}
-	attributes["gcp.cloudrun.service.iap-enabled"] = []string{strconv.FormatBool(s.IapEnabled)}
+	utils.SetBool(attributes, "gcp.cloudrun.service.invoker-iam-disabled", s.InvokerIamDisabled)
+	utils.SetBool(attributes, "gcp.cloudrun.service.iap-enabled", s.IapEnabled)
 
-	if s.Scaling != nil {
-		if s.Scaling.MinInstanceCount > 0 {
-			attributes["gcp.cloudrun.service.scaling.min-instance-count"] = []string{strconv.Itoa(int(s.Scaling.MinInstanceCount))}
-		}
-		if s.Scaling.ScalingMode != runpb.ServiceScaling_SCALING_MODE_UNSPECIFIED {
-			attributes["gcp.cloudrun.service.scaling.scaling-mode"] = []string{s.Scaling.ScalingMode.String()}
-		}
-	}
-
-	if tpl := s.Template; tpl != nil {
-		if tpl.MaxInstanceRequestConcurrency > 0 {
-			attributes["gcp.cloudrun.service.template.max-instance-request-concurrency"] = []string{strconv.Itoa(int(tpl.MaxInstanceRequestConcurrency))}
-		}
-		if tpl.Timeout != nil {
-			attributes["gcp.cloudrun.service.template.timeout"] = []string{tpl.Timeout.AsDuration().String()}
-		}
-		if tpl.ServiceAccount != "" {
-			attributes["gcp.cloudrun.service.template.service-account"] = []string{tpl.ServiceAccount}
-		}
-		if tpl.Scaling != nil {
-			if tpl.Scaling.MinInstanceCount > 0 {
-				attributes["gcp.cloudrun.service.template.scaling.min-instance-count"] = []string{strconv.Itoa(int(tpl.Scaling.MinInstanceCount))}
-			}
-			if tpl.Scaling.MaxInstanceCount > 0 {
-				attributes["gcp.cloudrun.service.template.scaling.max-instance-count"] = []string{strconv.Itoa(int(tpl.Scaling.MaxInstanceCount))}
-			}
-		}
-	}
+	addServiceScalingAttrs(attributes, s.Scaling)
+	addServiceTemplateAttrs(attributes, s.Template)
 
 	if len(s.Urls) > 0 {
 		attributes["gcp.cloudrun.service.urls"] = append([]string(nil), s.Urls...)
@@ -175,6 +146,36 @@ func toServiceTarget(s *runpb.Service, projectID string) discovery_kit_api.Targe
 		Label:      name,
 		Attributes: attributes,
 	}
+}
+
+func addServiceScalingAttrs(attrs map[string][]string, sc *runpb.ServiceScaling) {
+	if sc == nil {
+		return
+	}
+	utils.SetInt64IfPositive(attrs, "gcp.cloudrun.service.scaling.min-instance-count", int64(sc.MinInstanceCount))
+	if sc.ScalingMode != runpb.ServiceScaling_SCALING_MODE_UNSPECIFIED {
+		attrs["gcp.cloudrun.service.scaling.scaling-mode"] = []string{sc.ScalingMode.String()}
+	}
+}
+
+func addServiceTemplateAttrs(attrs map[string][]string, tpl *runpb.RevisionTemplate) {
+	if tpl == nil {
+		return
+	}
+	utils.SetInt64IfPositive(attrs, "gcp.cloudrun.service.template.max-instance-request-concurrency", int64(tpl.MaxInstanceRequestConcurrency))
+	if tpl.Timeout != nil {
+		attrs["gcp.cloudrun.service.template.timeout"] = []string{tpl.Timeout.AsDuration().String()}
+	}
+	utils.SetStr(attrs, "gcp.cloudrun.service.template.service-account", tpl.ServiceAccount)
+	addRevisionScalingAttrs(attrs, tpl.Scaling)
+}
+
+func addRevisionScalingAttrs(attrs map[string][]string, sc *runpb.RevisionScaling) {
+	if sc == nil {
+		return
+	}
+	utils.SetInt64IfPositive(attrs, "gcp.cloudrun.service.template.scaling.min-instance-count", int64(sc.MinInstanceCount))
+	utils.SetInt64IfPositive(attrs, "gcp.cloudrun.service.template.scaling.max-instance-count", int64(sc.MaxInstanceCount))
 }
 
 func parseServiceName(full string) (location, name string) {

--- a/extcloudsql/instance_discovery.go
+++ b/extcloudsql/instance_discovery.go
@@ -7,7 +7,6 @@ package extcloudsql
 import (
 	"context"
 	"fmt"
-	"strconv"
 	"strings"
 	"time"
 
@@ -116,56 +115,13 @@ func toInstanceTarget(inst *sqladmin.DatabaseInstance, projectID string) discove
 	attributes := make(map[string][]string)
 	attributes["gcp.project.id"] = []string{projectID}
 	attributes["gcp.cloudsql.instance.name"] = []string{inst.Name}
-	if inst.DatabaseVersion != "" {
-		attributes[attrDatabaseVersion] = []string{inst.DatabaseVersion}
-	}
-	if inst.Region != "" {
-		attributes[attrRegion] = []string{inst.Region}
-	}
-	if inst.GceZone != "" {
-		attributes["gcp.cloudsql.gce-zone"] = []string{inst.GceZone}
-	}
-	if inst.SecondaryGceZone != "" {
-		attributes["gcp.cloudsql.secondary-gce-zone"] = []string{inst.SecondaryGceZone}
-	}
-	if inst.State != "" {
-		attributes["gcp.cloudsql.state"] = []string{inst.State}
-	}
-	if inst.InstanceType != "" {
-		attributes["gcp.cloudsql.instance-type"] = []string{inst.InstanceType}
-	}
-	if inst.Settings != nil {
-		if inst.Settings.Tier != "" {
-			attributes[attrTier] = []string{inst.Settings.Tier}
-		}
-		if inst.Settings.AvailabilityType != "" {
-			attributes[attrAvailabilityType] = []string{inst.Settings.AvailabilityType}
-		}
-		if inst.Settings.BackupConfiguration != nil {
-			attributes["gcp.cloudsql.backup-enabled"] = []string{strconv.FormatBool(inst.Settings.BackupConfiguration.Enabled)}
-			attributes["gcp.cloudsql.point-in-time-recovery-enabled"] = []string{strconv.FormatBool(inst.Settings.BackupConfiguration.PointInTimeRecoveryEnabled)}
-		}
-		attributes["gcp.cloudsql.deletion-protection-enabled"] = []string{strconv.FormatBool(inst.Settings.DeletionProtectionEnabled)}
-		if inst.Settings.IpConfiguration != nil {
-			attributes["gcp.cloudsql.public-network-access"] = []string{strconv.FormatBool(inst.Settings.IpConfiguration.Ipv4Enabled)}
-			if inst.Settings.IpConfiguration.PrivateNetwork != "" {
-				attributes["gcp.cloudsql.private-network"] = []string{inst.Settings.IpConfiguration.PrivateNetwork}
-			}
-			attributes["gcp.cloudsql.require-ssl"] = []string{strconv.FormatBool(inst.Settings.IpConfiguration.RequireSsl)}
-		}
-		if inst.Settings.DataDiskType != "" {
-			attributes["gcp.cloudsql.disk-type"] = []string{inst.Settings.DataDiskType}
-		}
-		if inst.Settings.DataDiskSizeGb > 0 {
-			attributes["gcp.cloudsql.disk-size-gb"] = []string{strconv.FormatInt(inst.Settings.DataDiskSizeGb, 10)}
-		}
-		if inst.Settings.MaintenanceWindow != nil && inst.Settings.MaintenanceWindow.Day > 0 {
-			attributes["gcp.cloudsql.maintenance-window.day"] = []string{strconv.FormatInt(inst.Settings.MaintenanceWindow.Day, 10)}
-		}
-		for k, v := range inst.Settings.UserLabels {
-			attributes[fmt.Sprintf("gcp.cloudsql.label.%s", strings.ToLower(k))] = []string{v}
-		}
-	}
+	utils.SetStr(attributes, attrDatabaseVersion, inst.DatabaseVersion)
+	utils.SetStr(attributes, attrRegion, inst.Region)
+	utils.SetStr(attributes, "gcp.cloudsql.gce-zone", inst.GceZone)
+	utils.SetStr(attributes, "gcp.cloudsql.secondary-gce-zone", inst.SecondaryGceZone)
+	utils.SetStr(attributes, "gcp.cloudsql.state", inst.State)
+	utils.SetStr(attributes, "gcp.cloudsql.instance-type", inst.InstanceType)
+	addSettingsAttrs(attributes, inst.Settings)
 
 	return discovery_kit_api.Target{
 		Id:         fmt.Sprintf("projects/%s/instances/%s", projectID, inst.Name),
@@ -173,4 +129,45 @@ func toInstanceTarget(inst *sqladmin.DatabaseInstance, projectID string) discove
 		Label:      inst.Name,
 		Attributes: attributes,
 	}
+}
+
+func addSettingsAttrs(attrs map[string][]string, s *sqladmin.Settings) {
+	if s == nil {
+		return
+	}
+	utils.SetStr(attrs, attrTier, s.Tier)
+	utils.SetStr(attrs, attrAvailabilityType, s.AvailabilityType)
+	addBackupAttrs(attrs, s.BackupConfiguration)
+	utils.SetBool(attrs, "gcp.cloudsql.deletion-protection-enabled", s.DeletionProtectionEnabled)
+	addIpConfigAttrs(attrs, s.IpConfiguration)
+	utils.SetStr(attrs, "gcp.cloudsql.disk-type", s.DataDiskType)
+	utils.SetInt64IfPositive(attrs, "gcp.cloudsql.disk-size-gb", s.DataDiskSizeGb)
+	addMaintWindowAttrs(attrs, s.MaintenanceWindow)
+	for k, v := range s.UserLabels {
+		utils.SetStr(attrs, fmt.Sprintf("gcp.cloudsql.label.%s", strings.ToLower(k)), v)
+	}
+}
+
+func addBackupAttrs(attrs map[string][]string, b *sqladmin.BackupConfiguration) {
+	if b == nil {
+		return
+	}
+	utils.SetBool(attrs, "gcp.cloudsql.backup-enabled", b.Enabled)
+	utils.SetBool(attrs, "gcp.cloudsql.point-in-time-recovery-enabled", b.PointInTimeRecoveryEnabled)
+}
+
+func addIpConfigAttrs(attrs map[string][]string, ip *sqladmin.IpConfiguration) {
+	if ip == nil {
+		return
+	}
+	utils.SetBool(attrs, "gcp.cloudsql.public-network-access", ip.Ipv4Enabled)
+	utils.SetStr(attrs, "gcp.cloudsql.private-network", ip.PrivateNetwork)
+	utils.SetBool(attrs, "gcp.cloudsql.require-ssl", ip.RequireSsl)
+}
+
+func addMaintWindowAttrs(attrs map[string][]string, m *sqladmin.MaintenanceWindow) {
+	if m == nil {
+		return
+	}
+	utils.SetInt64IfPositive(attrs, "gcp.cloudsql.maintenance-window.day", m.Day)
 }

--- a/extdisk/disk_discovery.go
+++ b/extdisk/disk_discovery.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"fmt"
 	"sort"
-	"strconv"
 	"strings"
 	"time"
 
@@ -145,54 +144,21 @@ func toDiskTarget(disk *computepb.Disk, zone, region, projectID string) discover
 	attributes := make(map[string][]string)
 	attributes[attrProjectID] = []string{projectID}
 	attributes["gcp.persistent-disk.name"] = []string{disk.GetName()}
-	if zone != "" {
-		attributes[attrZone] = []string{zone}
-	}
-	if region != "" {
-		attributes["gcp.persistent-disk.region"] = []string{region}
-	}
-	if t := disk.GetType(); t != "" {
-		// type is a URL; surface the last path component for readability.
-		if i := strings.LastIndex(t, "/"); i >= 0 {
-			attributes[attrType] = []string{t[i+1:]}
-		} else {
-			attributes[attrType] = []string{t}
-		}
-	}
-	if v := disk.GetSizeGb(); v > 0 {
-		attributes[attrSizeGB] = []string{strconv.Itoa(int(v))}
-	}
-	if v := disk.GetStatus(); v != "" {
-		attributes["gcp.persistent-disk.status"] = []string{v}
-	}
-	if users := disk.GetUsers(); len(users) > 0 {
-		sorted := append([]string(nil), users...)
-		sort.Strings(sorted)
-		attributes["gcp.persistent-disk.users"] = sorted
-	}
-	if v := disk.GetSourceImage(); v != "" {
-		attributes["gcp.persistent-disk.source-image"] = []string{v}
-	}
-	if v := disk.GetSourceSnapshot(); v != "" {
-		attributes["gcp.persistent-disk.source-snapshot"] = []string{v}
-	}
-	if dek := disk.GetDiskEncryptionKey(); dek != nil && dek.GetKmsKeyName() != "" {
-		attributes["gcp.persistent-disk.kms-key-name"] = []string{dek.GetKmsKeyName()}
-	}
-	if v := disk.GetPhysicalBlockSizeBytes(); v > 0 {
-		attributes["gcp.persistent-disk.physical-block-size-bytes"] = []string{strconv.Itoa(int(v))}
-	}
-	if v := disk.GetProvisionedIops(); v > 0 {
-		attributes["gcp.persistent-disk.provisioned-iops"] = []string{strconv.Itoa(int(v))}
-	}
-	if v := disk.GetProvisionedThroughput(); v > 0 {
-		attributes["gcp.persistent-disk.provisioned-throughput"] = []string{strconv.Itoa(int(v))}
-	}
-	if v := disk.GetArchitecture(); v != "" {
-		attributes["gcp.persistent-disk.architecture"] = []string{v}
-	}
+	utils.SetStr(attributes, attrZone, zone)
+	utils.SetStr(attributes, "gcp.persistent-disk.region", region)
+	utils.SetStr(attributes, attrType, shortDiskType(disk.GetType()))
+	utils.SetInt64IfPositive(attributes, attrSizeGB, disk.GetSizeGb())
+	utils.SetStr(attributes, "gcp.persistent-disk.status", disk.GetStatus())
+	addDiskUsersAttr(attributes, disk.GetUsers())
+	utils.SetStr(attributes, "gcp.persistent-disk.source-image", disk.GetSourceImage())
+	utils.SetStr(attributes, "gcp.persistent-disk.source-snapshot", disk.GetSourceSnapshot())
+	addDiskEncryptionAttrs(attributes, disk.GetDiskEncryptionKey())
+	utils.SetInt64IfPositive(attributes, "gcp.persistent-disk.physical-block-size-bytes", disk.GetPhysicalBlockSizeBytes())
+	utils.SetInt64IfPositive(attributes, "gcp.persistent-disk.provisioned-iops", disk.GetProvisionedIops())
+	utils.SetInt64IfPositive(attributes, "gcp.persistent-disk.provisioned-throughput", disk.GetProvisionedThroughput())
+	utils.SetStr(attributes, "gcp.persistent-disk.architecture", disk.GetArchitecture())
 	for k, v := range disk.GetLabels() {
-		attributes[fmt.Sprintf("gcp.persistent-disk.label.%s", strings.ToLower(k))] = []string{v}
+		utils.SetStr(attributes, fmt.Sprintf("gcp.persistent-disk.label.%s", strings.ToLower(k)), v)
 	}
 
 	return discovery_kit_api.Target{
@@ -201,4 +167,32 @@ func toDiskTarget(disk *computepb.Disk, zone, region, projectID string) discover
 		Label:      disk.GetName(),
 		Attributes: attributes,
 	}
+}
+
+// shortDiskType returns the last path component of a disk type URL; the raw
+// value is returned unchanged when it has no "/" separator or is empty.
+func shortDiskType(t string) string {
+	if t == "" {
+		return ""
+	}
+	if i := strings.LastIndex(t, "/"); i >= 0 {
+		return t[i+1:]
+	}
+	return t
+}
+
+func addDiskUsersAttr(attrs map[string][]string, users []string) {
+	if len(users) == 0 {
+		return
+	}
+	sorted := append([]string(nil), users...)
+	sort.Strings(sorted)
+	attrs["gcp.persistent-disk.users"] = sorted
+}
+
+func addDiskEncryptionAttrs(attrs map[string][]string, dek *computepb.CustomerEncryptionKey) {
+	if dek == nil {
+		return
+	}
+	utils.SetStr(attrs, "gcp.persistent-disk.kms-key-name", dek.GetKmsKeyName())
 }

--- a/extgke/cluster_discovery.go
+++ b/extgke/cluster_discovery.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"fmt"
 	"sort"
-	"strconv"
 	"strings"
 	"time"
 
@@ -168,78 +167,106 @@ func toClusterTarget(c *containerpb.Cluster, projectID string) discovery_kit_api
 	// the kubeconfig context, which for GKE is the cluster name unless explicitly overridden).
 	attributes[attrK8sClusterName] = []string{c.Name}
 
-	if c.CurrentMasterVersion != "" {
-		attributes[attrClusterKubernetesVersion] = []string{c.CurrentMasterVersion}
-	}
-	if c.Status != containerpb.Cluster_STATUS_UNSPECIFIED {
-		attributes["gcp.gke.cluster.status"] = []string{c.Status.String()}
-	}
-	if c.ReleaseChannel != nil && c.ReleaseChannel.Channel != containerpb.ReleaseChannel_UNSPECIFIED {
-		attributes[attrClusterReleaseChannel] = []string{c.ReleaseChannel.Channel.String()}
-	}
-	if c.LoggingService != "" {
-		attributes[attrClusterLoggingService] = []string{c.LoggingService}
-	}
-	if c.MonitoringService != "" {
-		attributes[attrClusterMonitoringService] = []string{c.MonitoringService}
-	}
-	if c.Network != "" {
-		attributes[attrClusterNetwork] = []string{c.Network}
-	}
-	if c.Subnetwork != "" {
-		attributes[attrClusterSubnetwork] = []string{c.Subnetwork}
-	}
-	if len(c.Locations) > 0 {
-		locs := append([]string(nil), c.Locations...)
-		sort.Strings(locs)
-		attributes["gcp.gke.cluster.node-locations"] = locs
-	}
+	utils.SetStr(attributes, attrClusterKubernetesVersion, c.CurrentMasterVersion)
+	utils.SetStr(attributes, attrClusterLoggingService, c.LoggingService)
+	utils.SetStr(attributes, attrClusterMonitoringService, c.MonitoringService)
+	utils.SetStr(attributes, attrClusterNetwork, c.Network)
+	utils.SetStr(attributes, attrClusterSubnetwork, c.Subnetwork)
 
-	// "private cluster" in GKE parlance = worker nodes have no public IPs (EnablePrivateNodes).
-	// EnablePrivateEndpoint is a distinct control-plane setting (whether the API server has a public IP)
-	// and drives api-server-open-to-internet below.
-	privateNodes := c.PrivateClusterConfig != nil && c.PrivateClusterConfig.EnablePrivateNodes
-	privateEndpoint := c.PrivateClusterConfig != nil && c.PrivateClusterConfig.EnablePrivateEndpoint
-	attributes[attrClusterPrivateCluster] = []string{strconv.FormatBool(privateNodes)}
-
-	manEnabled := false
-	var manCidrs []string
-	if c.MasterAuthorizedNetworksConfig != nil {
-		manEnabled = c.MasterAuthorizedNetworksConfig.Enabled
-		for _, b := range c.MasterAuthorizedNetworksConfig.CidrBlocks {
-			if b != nil && b.CidrBlock != "" {
-				manCidrs = append(manCidrs, b.CidrBlock)
-			}
-		}
-	}
-	attributes[attrClusterMasterAuthorizedNetsEnabled] = []string{strconv.FormatBool(manEnabled)}
-	if len(manCidrs) > 0 {
-		sort.Strings(manCidrs)
-		attributes[attrClusterMasterAuthorizedNetsCidrs] = manCidrs
-	}
-	// True iff the API server is reachable from the public internet without IP restriction.
-	// Private endpoint => not internet-reachable. Public endpoint AND no authorized-networks restriction => open.
-	attributes[attrClusterApiServerOpenToInternet] = []string{strconv.FormatBool(!privateEndpoint && !manEnabled)}
-
-	wiEnabled := c.WorkloadIdentityConfig != nil && c.WorkloadIdentityConfig.WorkloadPool != ""
-	attributes[attrClusterWorkloadIdentityEnabled] = []string{strconv.FormatBool(wiEnabled)}
-
-	shielded := c.ShieldedNodes != nil && c.ShieldedNodes.Enabled
-	attributes[attrClusterShieldedNodesEnabled] = []string{strconv.FormatBool(shielded)}
-
-	if c.BinaryAuthorization != nil && c.BinaryAuthorization.EvaluationMode != containerpb.BinaryAuthorization_EVALUATION_MODE_UNSPECIFIED {
-		attributes[attrClusterBinaryAuthEvalMode] = []string{c.BinaryAuthorization.EvaluationMode.String()}
-	}
-
-	for k, v := range c.ResourceLabels {
-		attributes[fmt.Sprintf("gcp.gke.cluster.label.%s", strings.ToLower(k))] = []string{v}
-	}
+	addClusterStatusAttrs(attributes, c.Status)
+	addReleaseChannelAttrs(attributes, c.ReleaseChannel)
+	addNodeLocationsAttrs(attributes, c.Locations)
+	addNetworkAccessAttrs(attributes, c.PrivateClusterConfig, c.MasterAuthorizedNetworksConfig)
+	addWorkloadIdentityAttrs(attributes, c.WorkloadIdentityConfig)
+	addShieldedNodesAttrs(attributes, c.ShieldedNodes)
+	addBinaryAuthAttrs(attributes, c.BinaryAuthorization)
+	addClusterLabelAttrs(attributes, c.ResourceLabels)
 
 	return discovery_kit_api.Target{
 		Id:         fmt.Sprintf("projects/%s/locations/%s/clusters/%s", projectID, c.Location, c.Name),
 		TargetType: TargetIDCluster,
 		Label:      c.Name,
 		Attributes: attributes,
+	}
+}
+
+func addClusterStatusAttrs(attrs map[string][]string, status containerpb.Cluster_Status) {
+	if status == containerpb.Cluster_STATUS_UNSPECIFIED {
+		return
+	}
+	attrs["gcp.gke.cluster.status"] = []string{status.String()}
+}
+
+func addReleaseChannelAttrs(attrs map[string][]string, rc *containerpb.ReleaseChannel) {
+	if rc == nil || rc.Channel == containerpb.ReleaseChannel_UNSPECIFIED {
+		return
+	}
+	attrs[attrClusterReleaseChannel] = []string{rc.Channel.String()}
+}
+
+func addNodeLocationsAttrs(attrs map[string][]string, locations []string) {
+	if len(locations) == 0 {
+		return
+	}
+	locs := append([]string(nil), locations...)
+	sort.Strings(locs)
+	attrs["gcp.gke.cluster.node-locations"] = locs
+}
+
+// addNetworkAccessAttrs emits the three attributes that together describe control-plane and worker-node
+// network exposure. They are coupled because api-server-open-to-internet is derived from both private-cluster
+// and master-authorized-networks state.
+//
+// "private cluster" in GKE parlance = worker nodes have no public IPs (EnablePrivateNodes).
+// EnablePrivateEndpoint is a distinct control-plane setting (whether the API server has a public IP)
+// and drives api-server-open-to-internet.
+func addNetworkAccessAttrs(attrs map[string][]string, pc *containerpb.PrivateClusterConfig, man *containerpb.MasterAuthorizedNetworksConfig) {
+	privateNodes := pc != nil && pc.EnablePrivateNodes
+	privateEndpoint := pc != nil && pc.EnablePrivateEndpoint
+	utils.SetBool(attrs, attrClusterPrivateCluster, privateNodes)
+
+	manEnabled, manCidrs := extractMasterAuthorizedNetworks(man)
+	utils.SetBool(attrs, attrClusterMasterAuthorizedNetsEnabled, manEnabled)
+	if len(manCidrs) > 0 {
+		sort.Strings(manCidrs)
+		attrs[attrClusterMasterAuthorizedNetsCidrs] = manCidrs
+	}
+	// True iff the API server is reachable from the public internet without IP restriction.
+	// Private endpoint => not internet-reachable. Public endpoint AND no authorized-networks restriction => open.
+	utils.SetBool(attrs, attrClusterApiServerOpenToInternet, !privateEndpoint && !manEnabled)
+}
+
+func extractMasterAuthorizedNetworks(man *containerpb.MasterAuthorizedNetworksConfig) (bool, []string) {
+	if man == nil {
+		return false, nil
+	}
+	var cidrs []string
+	for _, b := range man.CidrBlocks {
+		if b != nil && b.CidrBlock != "" {
+			cidrs = append(cidrs, b.CidrBlock)
+		}
+	}
+	return man.Enabled, cidrs
+}
+
+func addWorkloadIdentityAttrs(attrs map[string][]string, wi *containerpb.WorkloadIdentityConfig) {
+	utils.SetBool(attrs, attrClusterWorkloadIdentityEnabled, wi != nil && wi.WorkloadPool != "")
+}
+
+func addShieldedNodesAttrs(attrs map[string][]string, sn *containerpb.ShieldedNodes) {
+	utils.SetBool(attrs, attrClusterShieldedNodesEnabled, sn != nil && sn.Enabled)
+}
+
+func addBinaryAuthAttrs(attrs map[string][]string, ba *containerpb.BinaryAuthorization) {
+	if ba == nil || ba.EvaluationMode == containerpb.BinaryAuthorization_EVALUATION_MODE_UNSPECIFIED {
+		return
+	}
+	attrs[attrClusterBinaryAuthEvalMode] = []string{ba.EvaluationMode.String()}
+}
+
+func addClusterLabelAttrs(attrs map[string][]string, labels map[string]string) {
+	for k, v := range labels {
+		utils.SetStr(attrs, fmt.Sprintf("gcp.gke.cluster.label.%s", strings.ToLower(k)), v)
 	}
 }
 

--- a/extgke/nodepool_attack_terminate_instances.go
+++ b/extgke/nodepool_attack_terminate_instances.go
@@ -124,24 +124,77 @@ func (a *nodePoolTerminateInstancesAttack) Describe() action_kit_api.ActionDescr
 	}
 }
 
+// migInstanceRef is a running MIG-managed instance selected for possible deletion.
+type migInstanceRef struct {
+	migZone string
+	migName string
+	url     string
+}
+
 func (a *nodePoolTerminateInstancesAttack) Prepare(ctx context.Context, state *NodePoolTerminateInstancesState, request action_kit_api.PrepareActionRequestBody) (*action_kit_api.PrepareResult, error) {
+	if err := populatePrepareTarget(state, request); err != nil {
+		return nil, err
+	}
+	pct, err := parsePreparePercentage(request)
+	if err != nil {
+		return nil, err
+	}
+	state.Percentage = pct
+
+	// Fetch fresh InstanceGroupUrls for the node pool — they may have changed since discovery.
+	np, err := fetchNodePoolForTerminate(ctx, state)
+	if err != nil {
+		return nil, err
+	}
+
+	migClient, closer, err := a.migClientProvider(ctx, state.ProjectID)
+	if err != nil {
+		return nil, extension_kit.ToError(fmt.Sprintf("Failed to create MIG client for project %s", state.ProjectID), err)
+	}
+	defer closer()
+
+	allInstances, err := collectRunningMigInstances(ctx, migClient, state.ProjectID, np.InstanceGroupUrls)
+	if err != nil {
+		return nil, err
+	}
+	if len(allInstances) == 0 {
+		return nil, extension_kit.ToError(fmt.Sprintf("GKE node pool %s/%s has no RUNNING instances to terminate", state.ClusterName, state.NodePoolName), nil)
+	}
+
+	sampleSize := computeSampleSize(len(allInstances), pct)
+	state.InstancesByMig = sampleMigInstances(allInstances, sampleSize, a.rng)
+
+	return &action_kit_api.PrepareResult{
+		Messages: extutil.Ptr([]action_kit_api.Message{{
+			Level:   extutil.Ptr(action_kit_api.Info),
+			Message: fmt.Sprintf("Selected %d of %d RUNNING instance(s) (%d%%) in GKE node pool %s/%s for deletion across %d MIG(s)", sampleSize, len(allInstances), pct, state.ClusterName, state.NodePoolName, len(state.InstancesByMig)),
+		}}),
+	}, nil
+}
+
+func populatePrepareTarget(state *NodePoolTerminateInstancesState, request action_kit_api.PrepareActionRequestBody) error {
 	state.ProjectID = mustHave(request.Target.Attributes, "gcp.project.id")
 	state.ClusterName = mustHave(request.Target.Attributes, attrClusterName)
 	state.NodePoolName = mustHave(request.Target.Attributes, "gcp.gke.nodepool.name")
 	state.Location = mustHave(request.Target.Attributes, "gcp.gke.cluster.location")
 	if state.ProjectID == "" || state.ClusterName == "" || state.NodePoolName == "" || state.Location == "" {
-		return nil, extension_kit.ToError("Target is missing one of: gcp.project.id, gcp.gke.cluster.name, gcp.gke.nodepool.name, gcp.gke.cluster.location", nil)
+		return extension_kit.ToError("Target is missing one of: gcp.project.id, gcp.gke.cluster.name, gcp.gke.nodepool.name, gcp.gke.cluster.location", nil)
 	}
+	return nil
+}
+
+func parsePreparePercentage(request action_kit_api.PrepareActionRequestBody) (int, error) {
 	pct := extutil.ToInt(request.Config["percentage"])
 	if pct < 1 || pct > 100 {
-		return nil, extension_kit.ToError("percentage must be between 1 and 100.", nil)
+		return 0, extension_kit.ToError("percentage must be between 1 and 100.", nil)
 	}
 	if pct > 50 && !extutil.ToBool(request.Config["confirmHighImpact"]) {
-		return nil, extension_kit.ToError("Percentages above 50% require the 'Allow percentages above 50%' flag — half the node pool will be deleted at once.", nil)
+		return 0, extension_kit.ToError("Percentages above 50% require the 'Allow percentages above 50%' flag — half the node pool will be deleted at once.", nil)
 	}
-	state.Percentage = pct
+	return pct, nil
+}
 
-	// Fetch fresh InstanceGroupUrls for the node pool — they may have changed since discovery.
+func fetchNodePoolForTerminate(ctx context.Context, state *NodePoolTerminateInstancesState) (*containerpb.NodePool, error) {
 	access, err := utils.GetGcpAccess(state.ProjectID)
 	if err != nil {
 		return nil, extension_kit.ToError(fmt.Sprintf("Failed to get GCP access for project %s", state.ProjectID), err)
@@ -160,74 +213,75 @@ func (a *nodePoolTerminateInstancesAttack) Prepare(ctx context.Context, state *N
 	if len(np.InstanceGroupUrls) == 0 {
 		return nil, extension_kit.ToError(fmt.Sprintf("GKE node pool %s/%s has no underlying instance groups", state.ClusterName, state.NodePoolName), nil)
 	}
+	return np, nil
+}
 
-	migClient, closer, err := a.migClientProvider(ctx, state.ProjectID)
-	if err != nil {
-		return nil, extension_kit.ToError(fmt.Sprintf("Failed to create MIG client for project %s", state.ProjectID), err)
-	}
-	defer closer()
-
-	type instanceRef struct {
-		migZone string
-		migName string
-		url     string
-	}
-	allInstances := make([]instanceRef, 0)
-	for _, igURL := range np.InstanceGroupUrls {
+func collectRunningMigInstances(ctx context.Context, client migInstancesApi, projectID string, igURLs []string) ([]migInstanceRef, error) {
+	all := make([]migInstanceRef, 0)
+	for _, igURL := range igURLs {
 		zone, name, ok := parseZonalMIGUrl(igURL)
 		if !ok {
 			// Regional MIGs aren't supported by GKE for node pools, but skip unknown URL shapes defensively.
 			continue
 		}
-		it := migClient.ListManagedInstances(ctx, &computepb.ListManagedInstancesInstanceGroupManagersRequest{
-			Project:              state.ProjectID,
-			Zone:                 zone,
-			InstanceGroupManager: name,
-		})
-		for {
-			mi, err := it.Next()
-			if err == iterator.Done {
-				break
-			}
-			if err != nil {
-				return nil, extension_kit.ToError(fmt.Sprintf("Failed to list instances of MIG %s/%s", zone, name), err)
-			}
-			// Only target currently running instances; skip those already being created/deleted/repaired.
-			if mi.GetInstanceStatus() != "RUNNING" {
-				continue
-			}
-			if mi.GetInstance() == "" {
-				continue
-			}
-			allInstances = append(allInstances, instanceRef{migZone: zone, migName: name, url: mi.GetInstance()})
+		refs, err := listRunningMigInstances(ctx, client, projectID, zone, name)
+		if err != nil {
+			return nil, err
 		}
+		all = append(all, refs...)
 	}
-	if len(allInstances) == 0 {
-		return nil, extension_kit.ToError(fmt.Sprintf("GKE node pool %s/%s has no RUNNING instances to terminate", state.ClusterName, state.NodePoolName), nil)
-	}
+	return all, nil
+}
 
-	// Sort for determinism, then random-sample N%.
-	sort.Slice(allInstances, func(i, j int) bool { return allInstances[i].url < allInstances[j].url })
-	sampleSize := int(math.Ceil(float64(len(allInstances)) * float64(pct) / 100.0))
+func listRunningMigInstances(ctx context.Context, client migInstancesApi, projectID, zone, name string) ([]migInstanceRef, error) {
+	it := client.ListManagedInstances(ctx, &computepb.ListManagedInstancesInstanceGroupManagersRequest{
+		Project:              projectID,
+		Zone:                 zone,
+		InstanceGroupManager: name,
+	})
+	var refs []migInstanceRef
+	for {
+		mi, err := it.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			return nil, extension_kit.ToError(fmt.Sprintf("Failed to list instances of MIG %s/%s", zone, name), err)
+		}
+		// Only target currently running instances; skip those already being created/deleted/repaired.
+		if mi.GetInstanceStatus() != "RUNNING" {
+			continue
+		}
+		if mi.GetInstance() == "" {
+			continue
+		}
+		refs = append(refs, migInstanceRef{migZone: zone, migName: name, url: mi.GetInstance()})
+	}
+	return refs, nil
+}
+
+func computeSampleSize(total, pct int) int {
+	sampleSize := int(math.Ceil(float64(total) * float64(pct) / 100.0))
 	if sampleSize < 1 {
 		sampleSize = 1
 	}
-	if sampleSize > len(allInstances) {
-		sampleSize = len(allInstances)
+	if sampleSize > total {
+		sampleSize = total
 	}
-	perm := a.rng(len(allInstances))
-	state.InstancesByMig = make(map[string][]string)
+	return sampleSize
+}
+
+func sampleMigInstances(refs []migInstanceRef, sampleSize int, rng func(n int) []int) map[string][]string {
+	// Sort for determinism, then random-sample N%.
+	sort.Slice(refs, func(i, j int) bool { return refs[i].url < refs[j].url })
+	perm := rng(len(refs))
+	out := make(map[string][]string)
 	for i := 0; i < sampleSize; i++ {
-		ref := allInstances[perm[i]]
+		ref := refs[perm[i]]
 		key := fmt.Sprintf("%s/%s", ref.migZone, ref.migName)
-		state.InstancesByMig[key] = append(state.InstancesByMig[key], ref.url)
+		out[key] = append(out[key], ref.url)
 	}
-	return &action_kit_api.PrepareResult{
-		Messages: extutil.Ptr([]action_kit_api.Message{{
-			Level:   extutil.Ptr(action_kit_api.Info),
-			Message: fmt.Sprintf("Selected %d of %d RUNNING instance(s) (%d%%) in GKE node pool %s/%s for deletion across %d MIG(s)", sampleSize, len(allInstances), pct, state.ClusterName, state.NodePoolName, len(state.InstancesByMig)),
-		}}),
-	}, nil
+	return out
 }
 
 func (a *nodePoolTerminateInstancesAttack) Start(ctx context.Context, state *NodePoolTerminateInstancesState) (*action_kit_api.StartResult, error) {

--- a/extgke/nodepool_discovery.go
+++ b/extgke/nodepool_discovery.go
@@ -135,61 +135,16 @@ func toNodePoolTarget(np *containerpb.NodePool, cluster *containerpb.Cluster, pr
 	attributes["k8s.cluster-name"] = []string{cluster.Name}
 	attributes["gcp.gke.nodepool.name"] = []string{np.Name}
 
-	if np.Version != "" {
-		attributes[attrNodePoolKubernetesVersion] = []string{np.Version}
-	}
-	if np.Status != containerpb.NodePool_STATUS_UNSPECIFIED {
-		attributes["gcp.gke.nodepool.status"] = []string{np.Status.String()}
-	}
-	if np.Config != nil {
-		if np.Config.MachineType != "" {
-			attributes[attrNodePoolMachineType] = []string{np.Config.MachineType}
-		}
-		if np.Config.DiskType != "" {
-			attributes["gcp.gke.nodepool.disk-type"] = []string{np.Config.DiskType}
-		}
-		if np.Config.DiskSizeGb > 0 {
-			attributes["gcp.gke.nodepool.disk-size-gb"] = []string{strconv.Itoa(int(np.Config.DiskSizeGb))}
-		}
-		if np.Config.ImageType != "" {
-			attributes["gcp.gke.nodepool.image-type"] = []string{np.Config.ImageType}
-		}
-		attributes["gcp.gke.nodepool.preemptible"] = []string{strconv.FormatBool(np.Config.Preemptible)}
-		attributes["gcp.gke.nodepool.spot"] = []string{strconv.FormatBool(np.Config.Spot)}
-	}
-	asEnabled := np.Autoscaling != nil && np.Autoscaling.Enabled
-	attributes[attrNodePoolAutoscalingEnabled] = []string{strconv.FormatBool(asEnabled)}
-	if asEnabled {
-		attributes["gcp.gke.nodepool.autoscaling.min-node-count"] = []string{strconv.Itoa(int(np.Autoscaling.MinNodeCount))}
-		attributes["gcp.gke.nodepool.autoscaling.max-node-count"] = []string{strconv.Itoa(int(np.Autoscaling.MaxNodeCount))}
-	}
-	if np.MaxPodsConstraint != nil && np.MaxPodsConstraint.MaxPodsPerNode > 0 {
-		attributes["gcp.gke.nodepool.max-pods-per-node"] = []string{strconv.Itoa(int(np.MaxPodsConstraint.MaxPodsPerNode))}
-	}
-	if np.Management != nil {
-		attributes["gcp.gke.nodepool.management.auto-upgrade"] = []string{strconv.FormatBool(np.Management.AutoUpgrade)}
-		attributes["gcp.gke.nodepool.management.auto-repair"] = []string{strconv.FormatBool(np.Management.AutoRepair)}
-	}
-	if np.UpgradeSettings != nil {
-		attributes["gcp.gke.nodepool.upgrade-settings.max-surge"] = []string{strconv.Itoa(int(np.UpgradeSettings.MaxSurge))}
-		attributes["gcp.gke.nodepool.upgrade-settings.max-unavailable"] = []string{strconv.Itoa(int(np.UpgradeSettings.MaxUnavailable))}
-	}
-	if len(np.Locations) > 0 {
-		locs := append([]string(nil), np.Locations...)
-		sort.Strings(locs)
-		attributes["gcp.gke.nodepool.locations"] = locs
-	}
-	if len(np.InstanceGroupUrls) > 0 {
-		urls := append([]string(nil), np.InstanceGroupUrls...)
-		sort.Strings(urls)
-		attributes["gcp.gke.nodepool.instance-group-urls"] = urls
-	}
+	utils.SetStr(attributes, attrNodePoolKubernetesVersion, np.Version)
 
-	if np.Config != nil {
-		for k, v := range np.Config.Labels {
-			attributes[fmt.Sprintf("gcp.gke.nodepool.label.%s", strings.ToLower(k))] = []string{v}
-		}
-	}
+	addNodePoolStatusAttrs(attributes, np.Status)
+	addNodePoolConfigAttrs(attributes, np.Config)
+	addNodePoolAutoscalingAttrs(attributes, np.Autoscaling)
+	addNodePoolMaxPodsAttrs(attributes, np.MaxPodsConstraint)
+	addNodePoolManagementAttrs(attributes, np.Management)
+	addNodePoolUpgradeSettingsAttrs(attributes, np.UpgradeSettings)
+	addNodePoolLocationsAttrs(attributes, np.Locations)
+	addNodePoolInstanceGroupUrlsAttrs(attributes, np.InstanceGroupUrls)
 
 	return discovery_kit_api.Target{
 		Id:         fmt.Sprintf("projects/%s/locations/%s/clusters/%s/nodePools/%s", projectID, cluster.Location, cluster.Name, np.Name),
@@ -197,4 +152,77 @@ func toNodePoolTarget(np *containerpb.NodePool, cluster *containerpb.Cluster, pr
 		Label:      fmt.Sprintf("%s/%s", cluster.Name, np.Name),
 		Attributes: attributes,
 	}
+}
+
+func addNodePoolStatusAttrs(attrs map[string][]string, status containerpb.NodePool_Status) {
+	if status == containerpb.NodePool_STATUS_UNSPECIFIED {
+		return
+	}
+	attrs["gcp.gke.nodepool.status"] = []string{status.String()}
+}
+
+func addNodePoolConfigAttrs(attrs map[string][]string, cfg *containerpb.NodeConfig) {
+	if cfg == nil {
+		return
+	}
+	utils.SetStr(attrs, attrNodePoolMachineType, cfg.MachineType)
+	utils.SetStr(attrs, "gcp.gke.nodepool.disk-type", cfg.DiskType)
+	utils.SetInt64IfPositive(attrs, "gcp.gke.nodepool.disk-size-gb", int64(cfg.DiskSizeGb))
+	utils.SetStr(attrs, "gcp.gke.nodepool.image-type", cfg.ImageType)
+	utils.SetBool(attrs, "gcp.gke.nodepool.preemptible", cfg.Preemptible)
+	utils.SetBool(attrs, "gcp.gke.nodepool.spot", cfg.Spot)
+	for k, v := range cfg.Labels {
+		utils.SetStr(attrs, fmt.Sprintf("gcp.gke.nodepool.label.%s", strings.ToLower(k)), v)
+	}
+}
+
+func addNodePoolAutoscalingAttrs(attrs map[string][]string, as *containerpb.NodePoolAutoscaling) {
+	asEnabled := as != nil && as.Enabled
+	utils.SetBool(attrs, attrNodePoolAutoscalingEnabled, asEnabled)
+	if !asEnabled {
+		return
+	}
+	attrs["gcp.gke.nodepool.autoscaling.min-node-count"] = []string{strconv.Itoa(int(as.MinNodeCount))}
+	attrs["gcp.gke.nodepool.autoscaling.max-node-count"] = []string{strconv.Itoa(int(as.MaxNodeCount))}
+}
+
+func addNodePoolMaxPodsAttrs(attrs map[string][]string, mpc *containerpb.MaxPodsConstraint) {
+	if mpc == nil {
+		return
+	}
+	utils.SetInt64IfPositive(attrs, "gcp.gke.nodepool.max-pods-per-node", mpc.MaxPodsPerNode)
+}
+
+func addNodePoolManagementAttrs(attrs map[string][]string, m *containerpb.NodeManagement) {
+	if m == nil {
+		return
+	}
+	utils.SetBool(attrs, "gcp.gke.nodepool.management.auto-upgrade", m.AutoUpgrade)
+	utils.SetBool(attrs, "gcp.gke.nodepool.management.auto-repair", m.AutoRepair)
+}
+
+func addNodePoolUpgradeSettingsAttrs(attrs map[string][]string, us *containerpb.NodePool_UpgradeSettings) {
+	if us == nil {
+		return
+	}
+	attrs["gcp.gke.nodepool.upgrade-settings.max-surge"] = []string{strconv.Itoa(int(us.MaxSurge))}
+	attrs["gcp.gke.nodepool.upgrade-settings.max-unavailable"] = []string{strconv.Itoa(int(us.MaxUnavailable))}
+}
+
+func addNodePoolLocationsAttrs(attrs map[string][]string, locations []string) {
+	if len(locations) == 0 {
+		return
+	}
+	locs := append([]string(nil), locations...)
+	sort.Strings(locs)
+	attrs["gcp.gke.nodepool.locations"] = locs
+}
+
+func addNodePoolInstanceGroupUrlsAttrs(attrs map[string][]string, urls []string) {
+	if len(urls) == 0 {
+		return
+	}
+	out := append([]string(nil), urls...)
+	sort.Strings(out)
+	attrs["gcp.gke.nodepool.instance-group-urls"] = out
 }

--- a/extmemorystore/redis_discovery.go
+++ b/extmemorystore/redis_discovery.go
@@ -7,7 +7,6 @@ package extmemorystore
 import (
 	"context"
 	"fmt"
-	"strconv"
 	"strings"
 	"time"
 
@@ -127,48 +126,32 @@ func toRedisTarget(inst *redispb.Instance, projectID string) discovery_kit_api.T
 	attributes := make(map[string][]string)
 	attributes[attrProjectID] = []string{projectID}
 	attributes["gcp.memorystore.instance.id"] = []string{instanceID}
-	if region != "" {
-		attributes[attrRegion] = []string{region}
-	}
+	utils.SetStr(attributes, attrRegion, region)
 	if inst.Tier != redispb.Instance_TIER_UNSPECIFIED {
 		attributes[attrTier] = []string{inst.Tier.String()}
 	}
-	if inst.RedisVersion != "" {
-		attributes[attrRedisVersion] = []string{inst.RedisVersion}
-	}
-	if inst.LocationId != "" {
-		attributes["gcp.memorystore.location-id"] = []string{inst.LocationId}
-	}
-	if inst.AlternativeLocationId != "" {
-		attributes["gcp.memorystore.alternative-location-id"] = []string{inst.AlternativeLocationId}
-	}
-	if inst.MemorySizeGb > 0 {
-		attributes["gcp.memorystore.memory-size-gb"] = []string{strconv.Itoa(int(inst.MemorySizeGb))}
-	}
+	utils.SetStr(attributes, attrRedisVersion, inst.RedisVersion)
+	utils.SetStr(attributes, "gcp.memorystore.location-id", inst.LocationId)
+	utils.SetStr(attributes, "gcp.memorystore.alternative-location-id", inst.AlternativeLocationId)
+	utils.SetInt64IfPositive(attributes, "gcp.memorystore.memory-size-gb", int64(inst.MemorySizeGb))
 	if inst.State != redispb.Instance_STATE_UNSPECIFIED {
 		attributes["gcp.memorystore.state"] = []string{inst.State.String()}
 	}
 	if inst.ConnectMode != redispb.Instance_CONNECT_MODE_UNSPECIFIED {
 		attributes["gcp.memorystore.connect-mode"] = []string{inst.ConnectMode.String()}
 	}
-	attributes["gcp.memorystore.auth-enabled"] = []string{strconv.FormatBool(inst.AuthEnabled)}
+	utils.SetBool(attributes, "gcp.memorystore.auth-enabled", inst.AuthEnabled)
 	if inst.TransitEncryptionMode != redispb.Instance_TRANSIT_ENCRYPTION_MODE_UNSPECIFIED {
 		attributes["gcp.memorystore.transit-encryption-mode"] = []string{inst.TransitEncryptionMode.String()}
 	}
 	if inst.ReadReplicasMode != redispb.Instance_READ_REPLICAS_MODE_UNSPECIFIED {
 		attributes["gcp.memorystore.read-replicas-mode"] = []string{inst.ReadReplicasMode.String()}
 	}
-	if inst.ReplicaCount > 0 {
-		attributes["gcp.memorystore.replica-count"] = []string{strconv.Itoa(int(inst.ReplicaCount))}
-	}
-	if inst.PersistenceConfig != nil && inst.PersistenceConfig.PersistenceMode != redispb.PersistenceConfig_PERSISTENCE_MODE_UNSPECIFIED {
-		attributes["gcp.memorystore.persistence-mode"] = []string{inst.PersistenceConfig.PersistenceMode.String()}
-	}
-	if inst.AuthorizedNetwork != "" {
-		attributes["gcp.memorystore.authorized-network"] = []string{inst.AuthorizedNetwork}
-	}
+	utils.SetInt64IfPositive(attributes, "gcp.memorystore.replica-count", int64(inst.ReplicaCount))
+	addPersistenceAttrs(attributes, inst.PersistenceConfig)
+	utils.SetStr(attributes, "gcp.memorystore.authorized-network", inst.AuthorizedNetwork)
 	for k, v := range inst.Labels {
-		attributes[fmt.Sprintf("gcp.memorystore.label.%s", strings.ToLower(k))] = []string{v}
+		utils.SetStr(attributes, fmt.Sprintf("gcp.memorystore.label.%s", strings.ToLower(k)), v)
 	}
 
 	return discovery_kit_api.Target{
@@ -176,5 +159,14 @@ func toRedisTarget(inst *redispb.Instance, projectID string) discovery_kit_api.T
 		TargetType: TargetIDRedisInstance,
 		Label:      instanceID,
 		Attributes: attributes,
+	}
+}
+
+func addPersistenceAttrs(attrs map[string][]string, p *redispb.PersistenceConfig) {
+	if p == nil {
+		return
+	}
+	if p.PersistenceMode != redispb.PersistenceConfig_PERSISTENCE_MODE_UNSPECIFIED {
+		attrs["gcp.memorystore.persistence-mode"] = []string{p.PersistenceMode.String()}
 	}
 }

--- a/extmig/mig_attack_delete_instances.go
+++ b/extmig/mig_attack_delete_instances.go
@@ -140,19 +140,12 @@ func (a *migDeleteInstancesAttack) Describe() action_kit_api.ActionDescription {
 }
 
 func (a *migDeleteInstancesAttack) Prepare(ctx context.Context, state *MigDeleteInstancesState, request action_kit_api.PrepareActionRequestBody) (*action_kit_api.PrepareResult, error) {
-	state.ProjectID = mustHave(request.Target.Attributes, "gcp.project.id")
-	state.Scope = mustHave(request.Target.Attributes, "gcp.mig.scope")
-	state.Location = mustHave(request.Target.Attributes, "gcp.mig.location")
-	state.MigName = mustHave(request.Target.Attributes, "gcp.mig.name")
-	if state.ProjectID == "" || state.Scope == "" || state.Location == "" || state.MigName == "" {
-		return nil, extension_kit.ToError("Target is missing one of: gcp.project.id, gcp.mig.scope, gcp.mig.location, gcp.mig.name", nil)
+	if err := hydrateStateFromTarget(state, request.Target.Attributes); err != nil {
+		return nil, err
 	}
-	pct := extutil.ToInt(request.Config["percentage"])
-	if pct < 1 || pct > 100 {
-		return nil, extension_kit.ToError("percentage must be between 1 and 100.", nil)
-	}
-	if pct > 50 && !extutil.ToBool(request.Config["confirmHighImpact"]) {
-		return nil, extension_kit.ToError("Percentages above 50% require the 'Allow percentages above 50%' flag — half the MIG will be deleted at once.", nil)
+	pct, err := validatePercentage(request.Config)
+	if err != nil {
+		return nil, err
 	}
 	state.Percentage = pct
 
@@ -164,78 +157,106 @@ func (a *migDeleteInstancesAttack) Prepare(ctx context.Context, state *MigDelete
 		return nil, extension_kit.ToError(fmt.Sprintf("MIG %s/%s has no RUNNING instances to delete", state.Location, state.MigName), nil)
 	}
 	sort.Strings(allInstances)
-	sampleSize := int(math.Ceil(float64(len(allInstances)) * float64(pct) / 100.0))
-	if sampleSize < 1 {
-		sampleSize = 1
-	}
-	if sampleSize > len(allInstances) {
-		sampleSize = len(allInstances)
-	}
-	perm := a.rng(len(allInstances))
-	state.Instances = make([]string, 0, sampleSize)
-	for i := 0; i < sampleSize; i++ {
-		state.Instances = append(state.Instances, allInstances[perm[i]])
-	}
+	state.Instances = sampleInstances(allInstances, pct, a.rng)
 	sort.Strings(state.Instances)
 	return &action_kit_api.PrepareResult{
 		Messages: extutil.Ptr([]action_kit_api.Message{{
 			Level:   extutil.Ptr(action_kit_api.Info),
-			Message: fmt.Sprintf("Selected %d of %d RUNNING instance(s) (%d%%) in MIG %s/%s for deletion", sampleSize, len(allInstances), pct, state.Location, state.MigName),
+			Message: fmt.Sprintf("Selected %d of %d RUNNING instance(s) (%d%%) in MIG %s/%s for deletion", len(state.Instances), len(allInstances), pct, state.Location, state.MigName),
 		}}),
 	}, nil
 }
 
+func hydrateStateFromTarget(state *MigDeleteInstancesState, attrs map[string][]string) error {
+	state.ProjectID = mustHave(attrs, "gcp.project.id")
+	state.Scope = mustHave(attrs, "gcp.mig.scope")
+	state.Location = mustHave(attrs, "gcp.mig.location")
+	state.MigName = mustHave(attrs, "gcp.mig.name")
+	if state.ProjectID == "" || state.Scope == "" || state.Location == "" || state.MigName == "" {
+		return extension_kit.ToError("Target is missing one of: gcp.project.id, gcp.mig.scope, gcp.mig.location, gcp.mig.name", nil)
+	}
+	return nil
+}
+
+func validatePercentage(cfg map[string]interface{}) (int, error) {
+	pct := extutil.ToInt(cfg["percentage"])
+	if pct < 1 || pct > 100 {
+		return 0, extension_kit.ToError("percentage must be between 1 and 100.", nil)
+	}
+	if pct > 50 && !extutil.ToBool(cfg["confirmHighImpact"]) {
+		return 0, extension_kit.ToError("Percentages above 50% require the 'Allow percentages above 50%' flag — half the MIG will be deleted at once.", nil)
+	}
+	return pct, nil
+}
+
+func sampleInstances(all []string, pct int, rng func(n int) []int) []string {
+	sampleSize := int(math.Ceil(float64(len(all)) * float64(pct) / 100.0))
+	if sampleSize < 1 {
+		sampleSize = 1
+	}
+	if sampleSize > len(all) {
+		sampleSize = len(all)
+	}
+	perm := rng(len(all))
+	result := make([]string, 0, sampleSize)
+	for i := 0; i < sampleSize; i++ {
+		result = append(result, all[perm[i]])
+	}
+	return result
+}
+
 func (a *migDeleteInstancesAttack) listRunningInstances(ctx context.Context, state *MigDeleteInstancesState) ([]string, error) {
-	result := make([]string, 0)
 	switch state.Scope {
 	case "zonal":
-		client, closer, err := a.zonalClientProvider(ctx, state.ProjectID)
-		if err != nil {
-			return nil, err
-		}
-		defer closer()
-		it := client.ListManagedInstances(ctx, &computepb.ListManagedInstancesInstanceGroupManagersRequest{
-			Project:              state.ProjectID,
-			Zone:                 state.Location,
-			InstanceGroupManager: state.MigName,
-		})
-		for {
-			mi, err := it.Next()
-			if err == iterator.Done {
-				break
-			}
-			if err != nil {
-				return nil, err
-			}
-			if mi.GetInstanceStatus() == "RUNNING" && mi.GetInstance() != "" {
-				result = append(result, mi.GetInstance())
-			}
-		}
+		return a.listZonalRunningInstances(ctx, state)
 	case "regional":
-		client, closer, err := a.regionalClientProvider(ctx, state.ProjectID)
-		if err != nil {
-			return nil, err
-		}
-		defer closer()
-		it := client.ListManagedInstances(ctx, &computepb.ListManagedInstancesRegionInstanceGroupManagersRequest{
-			Project:              state.ProjectID,
-			Region:               state.Location,
-			InstanceGroupManager: state.MigName,
-		})
-		for {
-			mi, err := it.Next()
-			if err == iterator.Done {
-				break
-			}
-			if err != nil {
-				return nil, err
-			}
-			if mi.GetInstanceStatus() == "RUNNING" && mi.GetInstance() != "" {
-				result = append(result, mi.GetInstance())
-			}
-		}
+		return a.listRegionalRunningInstances(ctx, state)
 	default:
 		return nil, fmt.Errorf("unsupported MIG scope %q", state.Scope)
+	}
+}
+
+func (a *migDeleteInstancesAttack) listZonalRunningInstances(ctx context.Context, state *MigDeleteInstancesState) ([]string, error) {
+	client, closer, err := a.zonalClientProvider(ctx, state.ProjectID)
+	if err != nil {
+		return nil, err
+	}
+	defer closer()
+	it := client.ListManagedInstances(ctx, &computepb.ListManagedInstancesInstanceGroupManagersRequest{
+		Project:              state.ProjectID,
+		Zone:                 state.Location,
+		InstanceGroupManager: state.MigName,
+	})
+	return collectRunningInstances(it)
+}
+
+func (a *migDeleteInstancesAttack) listRegionalRunningInstances(ctx context.Context, state *MigDeleteInstancesState) ([]string, error) {
+	client, closer, err := a.regionalClientProvider(ctx, state.ProjectID)
+	if err != nil {
+		return nil, err
+	}
+	defer closer()
+	it := client.ListManagedInstances(ctx, &computepb.ListManagedInstancesRegionInstanceGroupManagersRequest{
+		Project:              state.ProjectID,
+		Region:               state.Location,
+		InstanceGroupManager: state.MigName,
+	})
+	return collectRunningInstances(it)
+}
+
+func collectRunningInstances(it *compute.ManagedInstanceIterator) ([]string, error) {
+	result := make([]string, 0)
+	for {
+		mi, err := it.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		if mi.GetInstanceStatus() == "RUNNING" && mi.GetInstance() != "" {
+			result = append(result, mi.GetInstance())
+		}
 	}
 	return result, nil
 }

--- a/extmig/mig_discovery.go
+++ b/extmig/mig_discovery.go
@@ -139,58 +139,57 @@ func toMigTarget(mig *computepb.InstanceGroupManager, scope, location, projectID
 	attributes[attrScope] = []string{scope}
 	attributes[attrLocation] = []string{location}
 	attributes[attrTargetSize] = []string{strconv.Itoa(int(mig.GetTargetSize()))}
-	if v := mig.GetBaseInstanceName(); v != "" {
-		attributes["gcp.mig.base-instance-name"] = []string{v}
-	}
-	if v := mig.GetInstanceTemplate(); v != "" {
-		attributes["gcp.mig.instance-template"] = []string{v}
-	}
-
-	if dp := mig.GetDistributionPolicy(); dp != nil {
-		if v := dp.GetTargetShape(); v != "" {
-			attributes["gcp.mig.distribution-policy.target-shape"] = []string{v}
-		}
-		zones := make([]string, 0, len(dp.GetZones()))
-		for _, z := range dp.GetZones() {
-			if z != nil && z.Zone != nil && *z.Zone != "" {
-				zones = append(zones, *z.Zone)
-			}
-		}
-		if len(zones) > 0 {
-			attributes["gcp.mig.distribution-policy.zones"] = zones
-		}
-	}
-
-	if up := mig.GetUpdatePolicy(); up != nil {
-		if v := up.GetType(); v != "" {
-			attributes["gcp.mig.update-policy.type"] = []string{v}
-		}
-		if v := up.GetReplacementMethod(); v != "" {
-			attributes["gcp.mig.update-policy.replacement-method"] = []string{v}
-		}
-		if v := up.GetMinimalAction(); v != "" {
-			attributes["gcp.mig.update-policy.minimal-action"] = []string{v}
-		}
-	}
-
-	if ahps := mig.GetAutoHealingPolicies(); len(ahps) > 0 {
-		hcs := make([]string, 0, len(ahps))
-		for _, p := range ahps {
-			if p != nil && p.HealthCheck != nil && *p.HealthCheck != "" {
-				hcs = append(hcs, *p.HealthCheck)
-			}
-		}
-		if len(hcs) > 0 {
-			attributes["gcp.mig.auto-healing-policies.health-check"] = hcs
-		}
-	}
-
-	attributes["gcp.mig.stateful-policy.configured"] = []string{strconv.FormatBool(mig.GetStatefulPolicy() != nil)}
+	utils.SetStr(attributes, "gcp.mig.base-instance-name", mig.GetBaseInstanceName())
+	utils.SetStr(attributes, "gcp.mig.instance-template", mig.GetInstanceTemplate())
+	addDistributionPolicyAttrs(attributes, mig.GetDistributionPolicy())
+	addUpdatePolicyAttrs(attributes, mig.GetUpdatePolicy())
+	addAutoHealingAttrs(attributes, mig.GetAutoHealingPolicies())
+	utils.SetBool(attributes, "gcp.mig.stateful-policy.configured", mig.GetStatefulPolicy() != nil)
 
 	return discovery_kit_api.Target{
 		Id:         mig.GetSelfLink(),
 		TargetType: TargetIDMig,
 		Label:      mig.GetName(),
 		Attributes: attributes,
+	}
+}
+
+func addDistributionPolicyAttrs(attrs map[string][]string, dp *computepb.DistributionPolicy) {
+	if dp == nil {
+		return
+	}
+	utils.SetStr(attrs, "gcp.mig.distribution-policy.target-shape", dp.GetTargetShape())
+	zones := make([]string, 0, len(dp.GetZones()))
+	for _, z := range dp.GetZones() {
+		if z != nil && z.Zone != nil && *z.Zone != "" {
+			zones = append(zones, *z.Zone)
+		}
+	}
+	if len(zones) > 0 {
+		attrs["gcp.mig.distribution-policy.zones"] = zones
+	}
+}
+
+func addUpdatePolicyAttrs(attrs map[string][]string, up *computepb.InstanceGroupManagerUpdatePolicy) {
+	if up == nil {
+		return
+	}
+	utils.SetStr(attrs, "gcp.mig.update-policy.type", up.GetType())
+	utils.SetStr(attrs, "gcp.mig.update-policy.replacement-method", up.GetReplacementMethod())
+	utils.SetStr(attrs, "gcp.mig.update-policy.minimal-action", up.GetMinimalAction())
+}
+
+func addAutoHealingAttrs(attrs map[string][]string, ahps []*computepb.InstanceGroupManagerAutoHealingPolicy) {
+	if len(ahps) == 0 {
+		return
+	}
+	hcs := make([]string, 0, len(ahps))
+	for _, p := range ahps {
+		if p != nil && p.HealthCheck != nil && *p.HealthCheck != "" {
+			hcs = append(hcs, *p.HealthCheck)
+		}
+	}
+	if len(hcs) > 0 {
+		attrs["gcp.mig.auto-healing-policies.health-check"] = hcs
 	}
 }

--- a/extpubsub/subscription_discovery.go
+++ b/extpubsub/subscription_discovery.go
@@ -7,7 +7,6 @@ package extpubsub
 import (
 	"context"
 	"fmt"
-	"strconv"
 	"strings"
 	"time"
 
@@ -126,51 +125,23 @@ func toSubscriptionTarget(s *pubsubpb.Subscription, projectID string) discovery_
 	attributes := make(map[string][]string)
 	attributes[attrProjectID] = []string{projectID}
 	attributes["gcp.pubsub.subscription.name"] = []string{name}
-	if s.Topic != "" {
-		attributes[attrSubscriptionTopic] = []string{s.Topic}
-	}
+	utils.SetStr(attributes, attrSubscriptionTopic, s.Topic)
 	attributes[attrSubscriptionDeliveryType] = []string{deliveryType(s)}
-	if s.AckDeadlineSeconds > 0 {
-		attributes[attrSubscriptionAckDeadlineSeconds] = []string{strconv.Itoa(int(s.AckDeadlineSeconds))}
-	}
-	if s.MessageRetentionDuration != nil {
-		attributes["gcp.pubsub.subscription.message-retention-duration"] = []string{s.MessageRetentionDuration.AsDuration().String()}
-	}
-	attributes["gcp.pubsub.subscription.retain-acked-messages"] = []string{strconv.FormatBool(s.RetainAckedMessages)}
-	attributes["gcp.pubsub.subscription.enable-message-ordering"] = []string{strconv.FormatBool(s.EnableMessageOrdering)}
-	attributes["gcp.pubsub.subscription.enable-exactly-once-delivery"] = []string{strconv.FormatBool(s.EnableExactlyOnceDelivery)}
-	attributes["gcp.pubsub.subscription.detached"] = []string{strconv.FormatBool(s.Detached)}
-	if s.Filter != "" {
-		attributes["gcp.pubsub.subscription.filter"] = []string{s.Filter}
-	}
-	if s.State != pubsubpb.Subscription_STATE_UNSPECIFIED {
-		attributes["gcp.pubsub.subscription.state"] = []string{s.State.String()}
-	}
-	if s.PushConfig != nil && s.PushConfig.PushEndpoint != "" {
-		attributes["gcp.pubsub.subscription.push-config.endpoint"] = []string{s.PushConfig.PushEndpoint}
-	}
-	if s.DeadLetterPolicy != nil {
-		if s.DeadLetterPolicy.DeadLetterTopic != "" {
-			attributes["gcp.pubsub.subscription.dead-letter-policy.topic"] = []string{s.DeadLetterPolicy.DeadLetterTopic}
-		}
-		if s.DeadLetterPolicy.MaxDeliveryAttempts > 0 {
-			attributes["gcp.pubsub.subscription.dead-letter-policy.max-delivery-attempts"] = []string{strconv.Itoa(int(s.DeadLetterPolicy.MaxDeliveryAttempts))}
-		}
-	}
-	if s.RetryPolicy != nil {
-		if s.RetryPolicy.MinimumBackoff != nil {
-			attributes["gcp.pubsub.subscription.retry-policy.minimum-backoff"] = []string{s.RetryPolicy.MinimumBackoff.AsDuration().String()}
-		}
-		if s.RetryPolicy.MaximumBackoff != nil {
-			attributes["gcp.pubsub.subscription.retry-policy.maximum-backoff"] = []string{s.RetryPolicy.MaximumBackoff.AsDuration().String()}
-		}
-	}
-	if s.ExpirationPolicy != nil && s.ExpirationPolicy.Ttl != nil {
-		attributes["gcp.pubsub.subscription.expiration-policy.ttl"] = []string{s.ExpirationPolicy.Ttl.AsDuration().String()}
-	}
+	utils.SetInt64IfPositive(attributes, attrSubscriptionAckDeadlineSeconds, int64(s.AckDeadlineSeconds))
+	addMessageRetentionAttr(attributes, s)
+	utils.SetBool(attributes, "gcp.pubsub.subscription.retain-acked-messages", s.RetainAckedMessages)
+	utils.SetBool(attributes, "gcp.pubsub.subscription.enable-message-ordering", s.EnableMessageOrdering)
+	utils.SetBool(attributes, "gcp.pubsub.subscription.enable-exactly-once-delivery", s.EnableExactlyOnceDelivery)
+	utils.SetBool(attributes, "gcp.pubsub.subscription.detached", s.Detached)
+	utils.SetStr(attributes, "gcp.pubsub.subscription.filter", s.Filter)
+	addStateAttr(attributes, s.State)
+	addPushConfigAttrs(attributes, s.PushConfig)
+	addDeadLetterPolicyAttrs(attributes, s.DeadLetterPolicy)
+	addRetryPolicyAttrs(attributes, s.RetryPolicy)
+	addExpirationPolicyAttrs(attributes, s.ExpirationPolicy)
 
 	for k, v := range s.Labels {
-		attributes[fmt.Sprintf("gcp.pubsub.subscription.label.%s", strings.ToLower(k))] = []string{v}
+		utils.SetStr(attributes, fmt.Sprintf("gcp.pubsub.subscription.label.%s", strings.ToLower(k)), v)
 	}
 
 	return discovery_kit_api.Target{
@@ -178,6 +149,56 @@ func toSubscriptionTarget(s *pubsubpb.Subscription, projectID string) discovery_
 		TargetType: TargetIDSubscription,
 		Label:      name,
 		Attributes: attributes,
+	}
+}
+
+func addMessageRetentionAttr(attrs map[string][]string, s *pubsubpb.Subscription) {
+	if s.MessageRetentionDuration == nil {
+		return
+	}
+	attrs["gcp.pubsub.subscription.message-retention-duration"] = []string{s.MessageRetentionDuration.AsDuration().String()}
+}
+
+func addStateAttr(attrs map[string][]string, state pubsubpb.Subscription_State) {
+	if state == pubsubpb.Subscription_STATE_UNSPECIFIED {
+		return
+	}
+	attrs["gcp.pubsub.subscription.state"] = []string{state.String()}
+}
+
+func addPushConfigAttrs(attrs map[string][]string, p *pubsubpb.PushConfig) {
+	if p == nil {
+		return
+	}
+	utils.SetStr(attrs, "gcp.pubsub.subscription.push-config.endpoint", p.PushEndpoint)
+}
+
+func addDeadLetterPolicyAttrs(attrs map[string][]string, d *pubsubpb.DeadLetterPolicy) {
+	if d == nil {
+		return
+	}
+	utils.SetStr(attrs, "gcp.pubsub.subscription.dead-letter-policy.topic", d.DeadLetterTopic)
+	utils.SetInt64IfPositive(attrs, "gcp.pubsub.subscription.dead-letter-policy.max-delivery-attempts", int64(d.MaxDeliveryAttempts))
+}
+
+func addRetryPolicyAttrs(attrs map[string][]string, r *pubsubpb.RetryPolicy) {
+	if r == nil {
+		return
+	}
+	if r.MinimumBackoff != nil {
+		attrs["gcp.pubsub.subscription.retry-policy.minimum-backoff"] = []string{r.MinimumBackoff.AsDuration().String()}
+	}
+	if r.MaximumBackoff != nil {
+		attrs["gcp.pubsub.subscription.retry-policy.maximum-backoff"] = []string{r.MaximumBackoff.AsDuration().String()}
+	}
+}
+
+func addExpirationPolicyAttrs(attrs map[string][]string, e *pubsubpb.ExpirationPolicy) {
+	if e == nil {
+		return
+	}
+	if e.Ttl != nil {
+		attrs["gcp.pubsub.subscription.expiration-policy.ttl"] = []string{e.Ttl.AsDuration().String()}
 	}
 }
 

--- a/utils/attrs.go
+++ b/utils/attrs.go
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2026 steadybit GmbH. All rights reserved.
+ */
+
+package utils
+
+import "strconv"
+
+// Small helpers for populating discovery-target attribute maps. Each helper
+// wraps the "guard-then-assign" pattern that dominates every extXxx/*_discovery.go
+// toTarget function so those functions stay below Sonar's cognitive-complexity
+// threshold (go:S3776).
+
+// SetStr assigns attrs[key] = []string{value} only when value is non-empty.
+func SetStr(attrs map[string][]string, key, value string) {
+	if value != "" {
+		attrs[key] = []string{value}
+	}
+}
+
+// SetBool always assigns attrs[key] = []string{strconv.FormatBool(value)}.
+// Booleans have no natural "missing" value in the protos we surface — false is
+// a real signal, so this always writes.
+func SetBool(attrs map[string][]string, key string, value bool) {
+	attrs[key] = []string{strconv.FormatBool(value)}
+}
+
+// SetInt64IfPositive assigns the decimal form of value only when value > 0.
+// Used for fields the protos default to 0 to signal "unset" (e.g. DataDiskSizeGb,
+// MaintenanceWindow.Day).
+func SetInt64IfPositive(attrs map[string][]string, key string, value int64) {
+	if value > 0 {
+		attrs[key] = []string{strconv.FormatInt(value, 10)}
+	}
+}


### PR DESCRIPTION
## Summary

Fixes the 10 \`go:S3776\` cognitive-complexity issues Sonar flagged on \`main\` after #334 landed. Each affected function was a long chain of \`if x != \"\" { attrs[k] = ...}\` and nested \`if sub != nil { ... }\` proto-navigation blocks — complexity 16-32, all well above the 15 threshold.

**Stacked on top of #361** (batch A, the S1192 constants extraction) — the base of this PR is \`cleanup/sonar-s1192-constants\`, not \`main\`. Merge #361 first, then this rebases onto main cleanly. If you'd rather I re-base against main once #361 lands, just say the word.

## Approach

1. Introduce three helpers in \`utils/attrs.go\`:
   \`\`\`go
   utils.SetStr(attrs, key, value)             // writes only if value != ""
   utils.SetBool(attrs, key, value)            // always writes strconv.FormatBool(value)
   utils.SetInt64IfPositive(attrs, key, value) // writes only if value > 0
   \`\`\`
2. In each toTarget function, replace every flat guard with a helper call — collapses one \`if\` per attribute to zero.
3. Extract each nested \`if sub != nil { ... }\` block into an \`addXxxAttrs\` helper. Each helper starts with an early-return guard, then contains only flat calls.
4. Byte-identical attribute output — same keys, same values, same nil/empty-skip semantics.

## Complexity: before → after

| File / function | Before | After |
|---|---|---|
| extcloudrun/toServiceTarget | 25 | ~4 |
| extcloudsql/toInstanceTarget | 27 | ~5 |
| extdisk/toDiskTarget | 18 | ~1 |
| extgke/toClusterTarget | 25 | ~0 (pure delegation) |
| extgke/toNodePoolTarget | 22 | ~0 (pure delegation) |
| extgke/Prepare (terminate-instances) | 32 | ~6 |
| extmemorystore/toRedisTarget | 16 | ~7 |
| extmig/toMigTarget | 29 | below 15 |
| extmig/Prepare (delete-instances) | 29 | below 15 |
| extpubsub/toSubscriptionTarget | 21 | below 15 |

All extracted helpers are ≤5 complexity.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [x] All existing unit tests pass (\`go test ./... except /e2e\`)
- [x] Attribute output verified byte-identical (Bool via \`strconv.FormatBool\`; \`utils.SetInt64IfPositive\` with \`int64(x)\` cast matches \`strconv.Itoa(int(x))\` for the same value)
- [ ] Sonar re-scan after merge should show all 10 \`go:S3776\` findings resolved

## Follow-ups (not this PR)

The code-review workflow that ran against merged #334 surfaced **9 CONFIRMED correctness issues** — a separate PR is coming for those (nil-pointer panic in NAT disassociate, MIG 50% safety-gate bypass, GKE cross-project enrichment collision, etc.). This PR is quality-only, no behavioural changes.