### PR TITLE
fix: correctness follow-ups from PR #334 code review

### DIFF
--- a/charts/steadybit-extension-gcp/Chart.yaml
+++ b/charts/steadybit-extension-gcp/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: steadybit-extension-gcp
 description: Steadybit gcp extension Helm chart for Kubernetes.
-version: 1.2.0
+version: 1.2.1
 appVersion: v1.0.30
 home: https://www.steadybit.com/
 icon: https://steadybit-website-assets.s3.amazonaws.com/logo-symbol-transparent.png

--- a/charts/steadybit-extension-gcp/templates/deployment.yaml
+++ b/charts/steadybit-extension-gcp/templates/deployment.yaml
@@ -72,7 +72,15 @@ spec:
             {{- end }}
             {{- if .Values.gcp.projectIDs }}
             - name: STEADYBIT_EXTENSION_PROJECT_IDS
+              # Accept both `projectIDs: "a,b"` (CSV) and `projectIDs: [a, b]` (list).
+              # Without this dispatch, a YAML list — the natural shape given the plural
+              # name — Sprintf-formats to the literal string "[a b]", which envconfig
+              # then treats as a single bogus project ID.
+              {{- if kindIs "slice" .Values.gcp.projectIDs }}
+              value: {{ join "," .Values.gcp.projectIDs | quote }}
+              {{- else }}
               value: {{ .Values.gcp.projectIDs | quote }}
+              {{- end }}
             {{- end }}
             {{- if .Values.gcp.projectsAdvanced }}
             - name: STEADYBIT_EXTENSION_PROJECTS_ADVANCED

--- a/charts/steadybit-extension-gcp/values.yaml
+++ b/charts/steadybit-extension-gcp/values.yaml
@@ -149,8 +149,6 @@ gcp:
 
 
 discovery:
-  # discovery.group -- Optional group identifier. When set, the extension adds steadybit.group=<value> to every discovered target. Used as an additional matcher in enrichment rules.
-  group: ""
   attributes:
     excludes:
       # discovery.attributes.excludes.vm -- List of attributes to exclude from VM discovery.

--- a/extcloudrun/service_discovery.go
+++ b/extcloudrun/service_discovery.go
@@ -133,9 +133,10 @@ func toServiceTarget(s *runpb.Service, projectID string) discovery_kit_api.Targe
 	attributes["gcp.cloudrun.service.iap-enabled"] = []string{strconv.FormatBool(s.IapEnabled)}
 
 	if s.Scaling != nil {
-		if s.Scaling.MinInstanceCount > 0 {
-			attributes["gcp.cloudrun.service.scaling.min-instance-count"] = []string{strconv.Itoa(int(s.Scaling.MinInstanceCount))}
-		}
+		// Always emit min-instance-count — 0 is a real, targetable value (scale-to-zero),
+		// not "unset". Omitting it made scale-to-zero services indistinguishable from
+		// services with no scaling config.
+		attributes["gcp.cloudrun.service.scaling.min-instance-count"] = []string{strconv.Itoa(int(s.Scaling.MinInstanceCount))}
 		if s.Scaling.ScalingMode != runpb.ServiceScaling_SCALING_MODE_UNSPECIFIED {
 			attributes["gcp.cloudrun.service.scaling.scaling-mode"] = []string{s.Scaling.ScalingMode.String()}
 		}
@@ -152,9 +153,8 @@ func toServiceTarget(s *runpb.Service, projectID string) discovery_kit_api.Targe
 			attributes["gcp.cloudrun.service.template.service-account"] = []string{tpl.ServiceAccount}
 		}
 		if tpl.Scaling != nil {
-			if tpl.Scaling.MinInstanceCount > 0 {
-				attributes["gcp.cloudrun.service.template.scaling.min-instance-count"] = []string{strconv.Itoa(int(tpl.Scaling.MinInstanceCount))}
-			}
+			// Same rationale as above: 0 is a real value for min-instance-count.
+			attributes["gcp.cloudrun.service.template.scaling.min-instance-count"] = []string{strconv.Itoa(int(tpl.Scaling.MinInstanceCount))}
 			if tpl.Scaling.MaxInstanceCount > 0 {
 				attributes["gcp.cloudrun.service.template.scaling.max-instance-count"] = []string{strconv.Itoa(int(tpl.Scaling.MaxInstanceCount))}
 			}

--- a/extgke/cluster_discovery.go
+++ b/extgke/cluster_discovery.go
@@ -203,12 +203,17 @@ func toClusterTarget(c *containerpb.Cluster, projectID string) discovery_kit_api
 	attributes[attrClusterPrivateCluster] = []string{strconv.FormatBool(privateNodes)}
 
 	manEnabled := false
+	manRestricted := false // Enabled AND at least one non-0.0.0.0/0 CIDR.
 	var manCidrs []string
 	if c.MasterAuthorizedNetworksConfig != nil {
 		manEnabled = c.MasterAuthorizedNetworksConfig.Enabled
 		for _, b := range c.MasterAuthorizedNetworksConfig.CidrBlocks {
-			if b != nil && b.CidrBlock != "" {
-				manCidrs = append(manCidrs, b.CidrBlock)
+			if b == nil || b.CidrBlock == "" {
+				continue
+			}
+			manCidrs = append(manCidrs, b.CidrBlock)
+			if b.CidrBlock != "0.0.0.0/0" && b.CidrBlock != "::/0" {
+				manRestricted = true
 			}
 		}
 	}
@@ -218,8 +223,11 @@ func toClusterTarget(c *containerpb.Cluster, projectID string) discovery_kit_api
 		attributes[attrClusterMasterAuthorizedNetsCidrs] = manCidrs
 	}
 	// True iff the API server is reachable from the public internet without IP restriction.
-	// Private endpoint => not internet-reachable. Public endpoint AND no authorized-networks restriction => open.
-	attributes[attrClusterApiServerOpenToInternet] = []string{strconv.FormatBool(!privateEndpoint && !manEnabled)}
+	// Private endpoint => not internet-reachable. Otherwise, the network is
+	// "restricted" only if authorized-networks is enabled AND every allowed CIDR
+	// is narrower than 0.0.0.0/0 (::/0). A MAN-enabled cluster whose only rule
+	// is 0.0.0.0/0 is globally reachable and must report "open".
+	attributes[attrClusterApiServerOpenToInternet] = []string{strconv.FormatBool(!privateEndpoint && !manRestricted)}
 
 	wiEnabled := c.WorkloadIdentityConfig != nil && c.WorkloadIdentityConfig.WorkloadPool != ""
 	attributes[attrClusterWorkloadIdentityEnabled] = []string{strconv.FormatBool(wiEnabled)}
@@ -263,6 +271,15 @@ func (d *clusterDiscovery) DescribeEnrichmentRules() []discovery_kit_api.TargetE
 }
 
 func gkeClusterToK8sEnrichmentRule(destTargetType string) discovery_kit_api.TargetEnrichmentRule {
+	// KNOWN LIMITATION: this join keys on k8s.cluster-name only. When
+	// STEADYBIT_EXTENSION_PROJECTS_ADVANCED / _PROJECT_IDS is configured with
+	// multiple projects that each contain a cluster with the same name
+	// (e.g. two 'prod' clusters), enrichment on Kubernetes targets pulls
+	// attributes from whichever GKE cluster the enrichment engine sampled —
+	// so a query like `gcp.gke.cluster.name="prod"` can accidentally
+	// resolve to the wrong project's prod. The clean fix requires extension-
+	// kubernetes to also surface gcp.project.id on its targets so we can add
+	// it to both selectors here; tracked as a separate follow-up.
 	return discovery_kit_api.TargetEnrichmentRule{
 		Id:      fmt.Sprintf("com.steadybit.extension_gcp.gke.cluster-to-%s", destTargetType),
 		Version: extbuild.GetSemverVersionStringOrUnknown(),

--- a/extgke/cluster_discovery.go
+++ b/extgke/cluster_discovery.go
@@ -212,7 +212,12 @@ func toClusterTarget(c *containerpb.Cluster, projectID string) discovery_kit_api
 				continue
 			}
 			manCidrs = append(manCidrs, b.CidrBlock)
-			if b.CidrBlock != "0.0.0.0/0" && b.CidrBlock != "::/0" {
+			// Only credit a restriction when MAN is actually enabled. The API can
+			// return a stale CidrBlocks list on a disabled config; without this
+			// gate, a MAN-disabled cluster with leftover non-wildcard entries
+			// would be misreported as "restricted" (the opposite direction of the
+			// 0.0.0.0/0 misreport this fix is about).
+			if manEnabled && b.CidrBlock != "0.0.0.0/0" && b.CidrBlock != "::/0" {
 				manRestricted = true
 			}
 		}

--- a/extgke/nodepool_attack_terminate_instances.go
+++ b/extgke/nodepool_attack_terminate_instances.go
@@ -136,7 +136,8 @@ func (a *nodePoolTerminateInstancesAttack) Prepare(ctx context.Context, state *N
 	if pct < 1 || pct > 100 {
 		return nil, extension_kit.ToError("percentage must be between 1 and 100.", nil)
 	}
-	if pct > 50 && !extutil.ToBool(request.Config["confirmHighImpact"]) {
+	confirmHigh := extutil.ToBool(request.Config["confirmHighImpact"])
+	if pct > 50 && !confirmHigh {
 		return nil, extension_kit.ToError("Percentages above 50% require the 'Allow percentages above 50%' flag — half the node pool will be deleted at once.", nil)
 	}
 	state.Percentage = pct
@@ -208,12 +209,23 @@ func (a *nodePoolTerminateInstancesAttack) Prepare(ctx context.Context, state *N
 
 	// Sort for determinism, then random-sample N%.
 	sort.Slice(allInstances, func(i, j int) bool { return allInstances[i].url < allInstances[j].url })
-	sampleSize := int(math.Ceil(float64(len(allInstances)) * float64(pct) / 100.0))
+	// Use math.Floor (not math.Ceil) so the sample never exceeds the requested
+	// percentage — math.Ceil silently amplifies the effective impact past the
+	// 50 % gate on small node pools.
+	sampleSize := int(math.Floor(float64(len(allInstances)) * float64(pct) / 100.0))
 	if sampleSize < 1 {
 		sampleSize = 1
 	}
 	if sampleSize > len(allInstances) {
 		sampleSize = len(allInstances)
+	}
+	// Small-pool guard: the >=1 clamp can still push the effective ratio above
+	// 50 % (e.g. pct=50 on 1 node → 100 %). Refuse unless confirmHighImpact was
+	// explicitly set.
+	if sampleSize*2 > len(allInstances) && !confirmHigh {
+		return nil, extension_kit.ToError(fmt.Sprintf(
+			"Effective impact %d of %d node(s) exceeds 50%% (small node pool rounds up to a full node). Set 'Allow percentages above 50%%' to acknowledge.",
+			sampleSize, len(allInstances)), nil)
 	}
 	perm := a.rng(len(allInstances))
 	state.InstancesByMig = make(map[string][]string)

--- a/extmemorystore/redis_attack_failover.go
+++ b/extmemorystore/redis_attack_failover.go
@@ -94,13 +94,18 @@ func (a *redisFailoverAttack) Describe() action_kit_api.ActionDescription {
 	}
 }
 
-// dataProtectionFromString maps the parameter value to the SDK enum. Defaults to LIMITED_DATA_LOSS.
-func dataProtectionFromString(s string) redispb.FailoverInstanceRequest_DataProtectionMode {
+// dataProtectionFromString maps the parameter value to the SDK enum. Both
+// legal values are matched explicitly and the caller must pre-validate — an
+// unknown value returns (UNSPECIFIED, false) so we can error out instead of
+// silently downgrading a FORCE_DATA_LOSS request to LIMITED_DATA_LOSS.
+func dataProtectionFromString(s string) (redispb.FailoverInstanceRequest_DataProtectionMode, bool) {
 	switch s {
 	case "FORCE_DATA_LOSS":
-		return redispb.FailoverInstanceRequest_FORCE_DATA_LOSS
+		return redispb.FailoverInstanceRequest_FORCE_DATA_LOSS, true
+	case "LIMITED_DATA_LOSS":
+		return redispb.FailoverInstanceRequest_LIMITED_DATA_LOSS, true
 	default:
-		return redispb.FailoverInstanceRequest_LIMITED_DATA_LOSS
+		return redispb.FailoverInstanceRequest_DATA_PROTECTION_MODE_UNSPECIFIED, false
 	}
 }
 
@@ -116,6 +121,13 @@ func (a *redisFailoverAttack) Prepare(_ context.Context, state *RedisFailoverSta
 	}
 	state.InstanceName = fmt.Sprintf("projects/%s/locations/%s/instances/%s", state.ProjectID, region, state.InstanceID)
 	state.DataProtectionMode = extutil.ToString(request.Config["dataProtectionMode"])
+	// Validate the enum at Prepare so the user sees the error before we start.
+	// Silently downgrading to LIMITED_DATA_LOSS (the previous default-branch
+	// behaviour) would let a stale UI or typo hide a request for the destructive
+	// FORCE_DATA_LOSS mode.
+	if _, ok := dataProtectionFromString(state.DataProtectionMode); !ok {
+		return nil, extension_kit.ToError(fmt.Sprintf("Unknown dataProtectionMode %q; expected FORCE_DATA_LOSS or LIMITED_DATA_LOSS", state.DataProtectionMode), nil)
+	}
 	return nil, nil
 }
 
@@ -125,7 +137,11 @@ func (a *redisFailoverAttack) Start(ctx context.Context, state *RedisFailoverSta
 		return nil, extension_kit.ToError(fmt.Sprintf("Failed to initialize CloudRedis client for project %s", state.ProjectID), err)
 	}
 	defer closer()
-	mode := dataProtectionFromString(state.DataProtectionMode)
+	mode, ok := dataProtectionFromString(state.DataProtectionMode)
+	if !ok {
+		// Prepare validated this — belt & suspenders for a rehydrated / mutated state.
+		return nil, extension_kit.ToError(fmt.Sprintf("Unknown dataProtectionMode %q at Start; expected FORCE_DATA_LOSS or LIMITED_DATA_LOSS", state.DataProtectionMode), nil)
+	}
 	// FailoverInstance returns a long-running operation; we don't wait — chaos = fire-and-forget.
 	_, err = client.FailoverInstance(ctx, &redispb.FailoverInstanceRequest{
 		Name:               state.InstanceName,

--- a/extmig/mig_attack_delete_instances.go
+++ b/extmig/mig_attack_delete_instances.go
@@ -151,7 +151,8 @@ func (a *migDeleteInstancesAttack) Prepare(ctx context.Context, state *MigDelete
 	if pct < 1 || pct > 100 {
 		return nil, extension_kit.ToError("percentage must be between 1 and 100.", nil)
 	}
-	if pct > 50 && !extutil.ToBool(request.Config["confirmHighImpact"]) {
+	confirmHigh := extutil.ToBool(request.Config["confirmHighImpact"])
+	if pct > 50 && !confirmHigh {
 		return nil, extension_kit.ToError("Percentages above 50% require the 'Allow percentages above 50%' flag — half the MIG will be deleted at once.", nil)
 	}
 	state.Percentage = pct
@@ -164,12 +165,25 @@ func (a *migDeleteInstancesAttack) Prepare(ctx context.Context, state *MigDelete
 		return nil, extension_kit.ToError(fmt.Sprintf("MIG %s/%s has no RUNNING instances to delete", state.Location, state.MigName), nil)
 	}
 	sort.Strings(allInstances)
-	sampleSize := int(math.Ceil(float64(len(allInstances)) * float64(pct) / 100.0))
+	// Use math.Floor (not math.Ceil) so the sample never exceeds the requested
+	// percentage. math.Ceil on e.g. 3 * 50 / 100 = 1.5 rounds up to 2 = 67 %,
+	// which silently bypasses the confirmHighImpact gate at >50 %. Floor with a
+	// >=1 clamp keeps the "always kill at least one" property.
+	sampleSize := int(math.Floor(float64(len(allInstances)) * float64(pct) / 100.0))
 	if sampleSize < 1 {
 		sampleSize = 1
 	}
 	if sampleSize > len(allInstances) {
 		sampleSize = len(allInstances)
+	}
+	// Second guard: on very small MIGs the >=1 clamp can push the effective
+	// ratio above 50 % (e.g. pct=50 on 1 instance → 100 %). Refuse when this
+	// happens unless confirmHighImpact was explicitly set — otherwise the
+	// safety gate is silently bypassed by MIG size, not by user request.
+	if sampleSize*2 > len(allInstances) && !confirmHigh {
+		return nil, extension_kit.ToError(fmt.Sprintf(
+			"Effective impact %d of %d instance(s) exceeds 50%% (small MIG rounds up to a full instance). Set 'Allow percentages above 50%%' to acknowledge.",
+			sampleSize, len(allInstances)), nil)
 	}
 	perm := a.rng(len(allInstances))
 	state.Instances = make([]string, 0, sampleSize)

--- a/extnat/nat_attack_disassociate.go
+++ b/extnat/nat_attack_disassociate.go
@@ -118,11 +118,16 @@ func (a *cloudNatDisassociateAttack) Prepare(ctx context.Context, state *CloudNa
 	if err != nil {
 		return nil, extension_kit.ToError(fmt.Sprintf("Failed to get router %s/%s", state.Region, state.RouterName), err)
 	}
+	natFound := false
 	for _, nat := range router.GetNats() {
 		if nat.GetName() != state.NatName {
 			continue
 		}
+		natFound = true
 		for _, s := range nat.GetSubnetworks() {
+			if s == nil {
+				continue
+			}
 			snap := natSubnetSnapshot{}
 			if s.Name != nil {
 				snap.Name = *s.Name
@@ -132,6 +137,9 @@ func (a *cloudNatDisassociateAttack) Prepare(ctx context.Context, state *CloudNa
 			state.OriginalSubnetworks = append(state.OriginalSubnetworks, snap)
 		}
 		break
+	}
+	if !natFound {
+		return nil, extension_kit.ToError(fmt.Sprintf("Cloud NAT %s/%s not found on router — cannot disassociate", state.RouterName, state.NatName), nil)
 	}
 	if len(state.OriginalSubnetworks) == 0 {
 		return nil, extension_kit.ToError(fmt.Sprintf("Cloud NAT %s/%s has no subnetworks to disassociate", state.RouterName, state.NatName), nil)
@@ -182,12 +190,21 @@ func setNatSubnetworks(ctx context.Context, provider func(ctx context.Context, p
 	if err != nil {
 		return fmt.Errorf("get router: %w", err)
 	}
+	natFound := false
 	for _, nat := range router.GetNats() {
 		if nat.GetName() != state.NatName {
 			continue
 		}
 		nat.Subnetworks = toSubnetworkProtos(target)
+		natFound = true
 		break
+	}
+	if !natFound {
+		// The NAT was present at Prepare but is gone now (renamed / deleted).
+		// Refuse to PATCH the router unchanged — the caller reports "success"
+		// otherwise and any previously-disassociated subnetworks would stay
+		// disassociated indefinitely without an error signal to the user.
+		return fmt.Errorf("cloud NAT %q not found on router %q — refusing to PATCH unchanged", state.NatName, state.RouterName)
 	}
 	_, err = client.Patch(ctx, &computepb.PatchRouterRequest{
 		Project:        state.ProjectID,

--- a/extnat/nat_discovery.go
+++ b/extnat/nat_discovery.go
@@ -157,7 +157,10 @@ func toNatTarget(router *computepb.Router, nat *computepb.RouterNat, region, pro
 	if len(subnetNames) > 0 {
 		attributes["gcp.cloud-nat.subnetworks"] = subnetNames
 	}
-	attributes[attrSubnetworkCount] = []string{strconv.Itoa(len(subnets))}
+	// Count the same set we surfaced (filtered non-nil, non-empty names) so
+	// `subnetworks` and `subnetwork-count` don't disagree on how many things
+	// are attached.
+	attributes[attrSubnetworkCount] = []string{strconv.Itoa(len(subnetNames))}
 	if v := nat.GetMinPortsPerVm(); v != 0 {
 		attributes["gcp.cloud-nat.min-ports-per-vm"] = []string{strconv.Itoa(int(v))}
 	}


### PR DESCRIPTION
## Summary

Fixes the nine CONFIRMED correctness findings from an xhigh code-review pass on merged commit \`63b430b\`. Skips one finding (\#3 — GKE cross-project enrichment collision) because the fix requires extension-kubernetes to also surface \`gcp.project.id\` on its targets — flagged inline with a code comment.

Ships independently of the two Sonar cleanup PRs (#361 merged, #362 open); zero conflict with either.

## Safety-critical

- **MIG \`delete-instances\` — 50% gate bypass.** \`sampleSize = math.Ceil(N * pct / 100.0)\` amplified a nominal 50% request on a 3-instance MIG to 67% (2 instances). Switch to \`math.Floor\` with the existing \`>=1\` clamp, and add a **second guard** that refuses when the \`>=1\` clamp pushes the effective ratio above 50% (e.g. pct=50 on a 1-instance MIG → 100%). Same fix applied to the GKE \`terminate-instances\` attack — same bug, same file shape.

## Correctness

- **NAT Prepare nil-pointer.** Range over \`nat.GetSubnetworks()\` dereferenced \`s.Name\` without checking \`s != nil\`. Add the guard.
- **NAT silent no-op if renamed.** If the NAT was renamed/deleted between Prepare and Start/Stop, the setNatSubnetworks loop matched nothing and PATCHed the router unchanged — Start/Stop still reported success, leaving any previously-disassociated subnetworks disassociated indefinitely. Track a \`found\` flag and error out.
- **\`api-server-open-to-internet\` misreport.** A MAN-enabled cluster with a single \`0.0.0.0/0\` CIDR was reported as "protected" despite being globally reachable. Only credit a real restriction when there's at least one non-\`0.0.0.0/0\` (\`::/0\`) CIDR.
- **Memorystore \`dataProtectionMode\` silent downgrade.** Unknown / typo'd input default-branched to \`LIMITED_DATA_LOSS\` — a user requesting the destructive \`FORCE_DATA_LOSS\` mode via a stale UI could be silently switched to the graceful one. Return \`(enum, ok)\` and reject unknowns at Prepare.
- **Cloud Run scale-to-zero invisibility.** \`MinInstanceCount == 0\` was suppressed, making scale-to-zero services indistinguishable from services with no scaling config. Emit unconditionally.
- **NAT subnetwork-count / subnetworks disagreement.** Count and list disagreed on how many subnets were attached (raw slice vs. nil/empty-filtered names).

## Chart

- **\`gcp.projectIDs\` list-vs-CSV.** Passing a YAML list (natural given the plural name) resulted in a single literal \`"[a b]"\` project ID, and every GCP call 404'd. Dispatch on \`kindIs "slice"\` and join with commas.
- **Dead \`discovery.group\` knob.** Documented in values.yaml but no code, template, or config field ever consumed it. Removed.

## Deferred with a code comment

\`extgke/cluster_discovery.go\`: the GKE→Kubernetes enrichment rule keys on \`k8s.cluster-name\` alone. When multiple GCP projects contain clusters with the same name (e.g. two 'prod' clusters — a common convention), an arbitrary one wins. Real fix needs \`extension-kubernetes\` to surface \`gcp.project.id\` on its targets so both selectors can join on it. Inline comment added; tracked as a follow-up.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [x] \`go test ./...\` (non-e2e) passes
- [x] \`helm lint\` / \`helm unittest\` clean
- [ ] Manual verification of the two safety guards: dispatch delete-instances / terminate-instances against a 1-instance and 3-instance target with various \`pct\` / \`confirmHighImpact\` combinations