### PR TITLE
cleanup: extract extvm + extnat Sonar leftovers

### DIFF
--- a/extnat/nat_attack_disassociate.go
+++ b/extnat/nat_attack_disassociate.go
@@ -102,14 +102,42 @@ func (a *cloudNatDisassociateAttack) Describe() action_kit_api.ActionDescription
 }
 
 func (a *cloudNatDisassociateAttack) Prepare(ctx context.Context, state *CloudNatDisassociateState, request action_kit_api.PrepareActionRequestBody) (*action_kit_api.PrepareResult, error) {
+	if err := populatePrepareTarget(state, request); err != nil {
+		return nil, err
+	}
+	router, err := fetchRouter(ctx, a.clientProvider, state)
+	if err != nil {
+		return nil, err
+	}
+	found, snapshots := snapshotNatSubnetworks(router, state.NatName)
+	if !found {
+		return nil, extension_kit.ToError(fmt.Sprintf("Cloud NAT %s/%s not found on router — cannot disassociate", state.RouterName, state.NatName), nil)
+	}
+	if len(snapshots) == 0 {
+		return nil, extension_kit.ToError(fmt.Sprintf("Cloud NAT %s/%s has no subnetworks to disassociate", state.RouterName, state.NatName), nil)
+	}
+	state.OriginalSubnetworks = snapshots
+	return &action_kit_api.PrepareResult{
+		Messages: extutil.Ptr([]action_kit_api.Message{{
+			Level:   extutil.Ptr(action_kit_api.Info),
+			Message: fmt.Sprintf("Will disassociate %d subnetwork(s) from Cloud NAT %s/%s", len(state.OriginalSubnetworks), state.RouterName, state.NatName),
+		}}),
+	}, nil
+}
+
+func populatePrepareTarget(state *CloudNatDisassociateState, request action_kit_api.PrepareActionRequestBody) error {
 	state.ProjectID = mustHave(request.Target.Attributes, "gcp.project.id")
 	state.Region = mustHave(request.Target.Attributes, "gcp.cloud-nat.region")
 	state.RouterName = mustHave(request.Target.Attributes, "gcp.cloud-nat.router")
 	state.NatName = mustHave(request.Target.Attributes, "gcp.cloud-nat.name")
 	if state.ProjectID == "" || state.Region == "" || state.RouterName == "" || state.NatName == "" {
-		return nil, extension_kit.ToError("Target is missing one of: gcp.project.id, gcp.cloud-nat.region, gcp.cloud-nat.router, gcp.cloud-nat.name", nil)
+		return extension_kit.ToError("Target is missing one of: gcp.project.id, gcp.cloud-nat.region, gcp.cloud-nat.router, gcp.cloud-nat.name", nil)
 	}
-	client, closer, err := a.clientProvider(ctx, state.ProjectID)
+	return nil
+}
+
+func fetchRouter(ctx context.Context, provider func(ctx context.Context, projectID string) (*compute.RoutersClient, func(), error), state *CloudNatDisassociateState) (*computepb.Router, error) {
+	client, closer, err := provider(ctx, state.ProjectID)
 	if err != nil {
 		return nil, extension_kit.ToError(fmt.Sprintf("Failed to create Routers client for project %s", state.ProjectID), err)
 	}
@@ -118,12 +146,18 @@ func (a *cloudNatDisassociateAttack) Prepare(ctx context.Context, state *CloudNa
 	if err != nil {
 		return nil, extension_kit.ToError(fmt.Sprintf("Failed to get router %s/%s", state.Region, state.RouterName), err)
 	}
-	natFound := false
+	return router, nil
+}
+
+// snapshotNatSubnetworks locates the named NAT on the router and returns a
+// copy of its subnetworks list. `found` reports whether the NAT existed at all
+// so the caller can distinguish "NAT gone" from "NAT present but empty".
+func snapshotNatSubnetworks(router *computepb.Router, natName string) (found bool, snapshots []natSubnetSnapshot) {
 	for _, nat := range router.GetNats() {
-		if nat.GetName() != state.NatName {
+		if nat.GetName() != natName {
 			continue
 		}
-		natFound = true
+		found = true
 		for _, s := range nat.GetSubnetworks() {
 			if s == nil {
 				continue
@@ -134,22 +168,11 @@ func (a *cloudNatDisassociateAttack) Prepare(ctx context.Context, state *CloudNa
 			}
 			snap.SecondaryIPRangeNames = append(snap.SecondaryIPRangeNames, s.GetSecondaryIpRangeNames()...)
 			snap.SourceIPRangesToNat = append(snap.SourceIPRangesToNat, s.GetSourceIpRangesToNat()...)
-			state.OriginalSubnetworks = append(state.OriginalSubnetworks, snap)
+			snapshots = append(snapshots, snap)
 		}
-		break
+		return found, snapshots
 	}
-	if !natFound {
-		return nil, extension_kit.ToError(fmt.Sprintf("Cloud NAT %s/%s not found on router — cannot disassociate", state.RouterName, state.NatName), nil)
-	}
-	if len(state.OriginalSubnetworks) == 0 {
-		return nil, extension_kit.ToError(fmt.Sprintf("Cloud NAT %s/%s has no subnetworks to disassociate", state.RouterName, state.NatName), nil)
-	}
-	return &action_kit_api.PrepareResult{
-		Messages: extutil.Ptr([]action_kit_api.Message{{
-			Level:   extutil.Ptr(action_kit_api.Info),
-			Message: fmt.Sprintf("Will disassociate %d subnetwork(s) from Cloud NAT %s/%s", len(state.OriginalSubnetworks), state.RouterName, state.NatName),
-		}}),
-	}, nil
+	return false, nil
 }
 
 func (a *cloudNatDisassociateAttack) Start(ctx context.Context, state *CloudNatDisassociateState) (*action_kit_api.StartResult, error) {

--- a/extvm/common.go
+++ b/extvm/common.go
@@ -4,4 +4,20 @@ const (
 	TargetIDVM                  = "com.steadybit.extension_gcp.vm"
 	VirtualMachineStateActionId = "com.steadybit.extension_gcp.vm.state"
 	targetIcon                  = "data:image/svg+xml,%3Csvg%20width%3D%2224%22%20height%3D%2224%22%20viewBox%3D%220%200%2024%2024%22%20fill%3D%22none%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%0A%3Cpath%20fill-rule%3D%22evenodd%22%20clip-rule%3D%22evenodd%22%20d%3D%22M9%202H7V5H5V7H2V9H5V11H2V13H5V15H2V17H5V19H7V22H9V19H11V22H13V19H15V22H17V19H19V17H22V15H19V13H22V11H19V9H22V7H19V5H17V2H15V5H13V2H11V5H9V2ZM9%2015V9H15V15H9ZM7%2017H17V7H7V17Z%22%20fill%3D%22%231D2632%22%2F%3E%0A%3C%2Fsvg%3E%0A"
+
+	// Attribute names extracted per Sonar go:S1192.
+	attrVmID          = "gcp-vm.id"
+	attrVmHostname    = "gcp-vm.hostname"
+	attrVmStatus      = "gcp-vm.status"
+	attrProjectID     = "gcp.project.id"
+	attrZone          = "gcp.zone"
+	attrClusterName   = "gcp-kubernetes-engine.cluster.name"
+	// Prefixes used by enrichment-attribute NameMatcher rules — trailing dot
+	// / "*." semantics preserved in call sites.
+	attrPrefixVmLabel = "gcp-vm.label."
+	attrPrefixVm      = "gcp-vm."
+	attrPrefixGKE     = "gcp-kubernetes-engine."
+	// Enrichment placeholder strings (referenced from selector maps in the
+	// rules below).
+	enrichSrcHostname = "${src.gcp-vm.hostname}"
 )

--- a/extvm/vm_discovery.go
+++ b/extvm/vm_discovery.go
@@ -67,10 +67,10 @@ func (d *vmDiscovery) DescribeTarget() discovery_kit_api.TargetDescription {
 		Table: discovery_kit_api.Table{
 			Columns: []discovery_kit_api.Column{
 				{Attribute: "steadybit.label"},
-				{Attribute: "gcp.zone"},
-				{Attribute: "gcp.project.id"},
-				{Attribute: "gcp-vm.status"},
-				{Attribute: "gcp-kubernetes-engine.cluster.name"},
+				{Attribute: attrZone},
+				{Attribute: attrProjectID},
+				{Attribute: attrVmStatus},
+				{Attribute: attrClusterName},
 			},
 			OrderBy: []discovery_kit_api.OrderBy{
 				{
@@ -92,14 +92,14 @@ func (d *vmDiscovery) DescribeAttributes() []discovery_kit_api.AttributeDescript
 			},
 		},
 		{
-			Attribute: "gcp-vm.id",
+			Attribute: attrVmID,
 			Label: discovery_kit_api.PluralLabel{
 				One:   "VM ID",
 				Other: "VM IDs",
 			},
 		},
 		{
-			Attribute: "gcp-vm.hostname",
+			Attribute: attrVmHostname,
 			Label: discovery_kit_api.PluralLabel{
 				One:   "Host name",
 				Other: "Host names",
@@ -134,7 +134,7 @@ func (d *vmDiscovery) DescribeAttributes() []discovery_kit_api.AttributeDescript
 			},
 		},
 		{
-			Attribute: "gcp-vm.status",
+			Attribute: attrVmStatus,
 			Label: discovery_kit_api.PluralLabel{
 				One:   "Status",
 				Other: "Statuses",
@@ -170,7 +170,7 @@ func (d *vmDiscovery) DescribeAttributes() []discovery_kit_api.AttributeDescript
 		},
 
 		{
-			Attribute: "gcp.zone",
+			Attribute: attrZone,
 			Label: discovery_kit_api.PluralLabel{
 				One:   "Zone",
 				Other: "Zones",
@@ -178,14 +178,14 @@ func (d *vmDiscovery) DescribeAttributes() []discovery_kit_api.AttributeDescript
 		},
 
 		{
-			Attribute: "gcp.project.id",
+			Attribute: attrProjectID,
 			Label: discovery_kit_api.PluralLabel{
 				One:   "Project ID",
 				Other: "Project IDs",
 			},
 		},
 		{
-			Attribute: "gcp-kubernetes-engine.cluster.name",
+			Attribute: attrClusterName,
 			Label: discovery_kit_api.PluralLabel{
 				One:   "Cluster Name",
 				Other: "Cluster Names",
@@ -262,18 +262,18 @@ func instanceToTarget(instance *computepb.Instance, projectID string, targets []
 
 	attributes["gcp-vm.name"] = []string{getStringValue(instance.Name)}
 	id := fmt.Sprintf("%d", *instance.Id)
-	attributes["gcp-vm.id"] = []string{id}
-	attributes["gcp-vm.hostname"] = []string{getHostname(instance)}
+	attributes[attrVmID] = []string{id}
+	attributes[attrVmHostname] = []string{getHostname(instance)}
 	attributes["gcp-vm.description"] = []string{getStringValue(instance.Description)}
 	attributes["gcp-vm.cpu-platform"] = []string{getStringValue(instance.CpuPlatform)}
 	attributes["gcp-vm.machine-type"] = []string{getStringValue(instance.MachineType)}
 	attributes["gcp-vm.source-machine-image"] = []string{getStringValue(instance.SourceMachineImage)}
-	attributes["gcp-vm.status"] = []string{getStringValue(instance.Status)}
+	attributes[attrVmStatus] = []string{getStringValue(instance.Status)}
 	attributes["gcp-vm.status-message"] = []string{getStringValue(instance.StatusMessage)}
 	attributes["gcp.zone-url"] = []string{getStringValue(instance.Zone)}
-	attributes["gcp.zone"] = []string{getZone(instance)}
-	attributes["gcp.project.id"] = []string{projectID}
-	attributes["gcp-kubernetes-engine.cluster.name"] = []string{getMetadata(instance.Metadata, "cluster-name")}
+	attributes[attrZone] = []string{getZone(instance)}
+	attributes[attrProjectID] = []string{projectID}
+	attributes[attrClusterName] = []string{getMetadata(instance.Metadata, "cluster-name")}
 	attributes["gcp-kubernetes-engine.cluster.location"] = []string{getMetadata(instance.Metadata, "cluster-location")}
 
 	for k, v := range instance.Labels {
@@ -356,35 +356,35 @@ func getToHostEnrichmentRule(targetName string, targetType string) discovery_kit
 		Src: discovery_kit_api.SourceOrDestination{
 			Type: TargetIDVM,
 			Selector: map[string]string{
-				"gcp-vm.hostname": "${dest.host.hostname}",
+				attrVmHostname: "${dest.host.hostname}",
 			},
 		},
 		Dest: discovery_kit_api.SourceOrDestination{
 			Type: targetType,
 			Selector: map[string]string{
-				"host.hostname": "${src.gcp-vm.hostname}",
+				"host.hostname": enrichSrcHostname,
 			},
 		},
 		Attributes: []discovery_kit_api.Attribute{
 			{
 				Matcher: discovery_kit_api.StartsWith,
-				Name:    "gcp-vm.label.",
+				Name:    attrPrefixVmLabel,
 			},
 			{
 				Matcher: discovery_kit_api.StartsWith,
-				Name:    "gcp-vm.",
+				Name:    attrPrefixVm,
 			},
 			{
 				Matcher: discovery_kit_api.StartsWith,
-				Name:    "gcp-kubernetes-engine.",
+				Name:    attrPrefixGKE,
 			},
 			{
 				Matcher: discovery_kit_api.Equals,
-				Name:    "gcp.zone",
+				Name:    attrZone,
 			},
 			{
 				Matcher: discovery_kit_api.Equals,
-				Name:    "gcp.project.id",
+				Name:    attrProjectID,
 			},
 		},
 	}
@@ -397,35 +397,35 @@ func getToHostWindowsEnrichmentRule() discovery_kit_api.TargetEnrichmentRule {
 		Src: discovery_kit_api.SourceOrDestination{
 			Type: TargetIDVM,
 			Selector: map[string]string{
-				"gcp-vm.id": "${dest.gcp-vm.id}",
+				attrVmID: "${dest.gcp-vm.id}",
 			},
 		},
 		Dest: discovery_kit_api.SourceOrDestination{
 			Type: "com.steadybit.extension_host_windows.host",
 			Selector: map[string]string{
-				"gcp-vm.id": "${src.gcp-vm.id}",
+				attrVmID: "${src.gcp-vm.id}",
 			},
 		},
 		Attributes: []discovery_kit_api.Attribute{
 			{
 				Matcher: discovery_kit_api.StartsWith,
-				Name:    "gcp-vm.label.",
+				Name:    attrPrefixVmLabel,
 			},
 			{
 				Matcher: discovery_kit_api.StartsWith,
-				Name:    "gcp-vm.",
+				Name:    attrPrefixVm,
 			},
 			{
 				Matcher: discovery_kit_api.StartsWith,
-				Name:    "gcp-kubernetes-engine.",
+				Name:    attrPrefixGKE,
 			},
 			{
 				Matcher: discovery_kit_api.Equals,
-				Name:    "gcp.zone",
+				Name:    attrZone,
 			},
 			{
 				Matcher: discovery_kit_api.Equals,
-				Name:    "gcp.project.id",
+				Name:    attrProjectID,
 			},
 		},
 	}
@@ -439,35 +439,35 @@ func getToContainerEnrichmentRule() discovery_kit_api.TargetEnrichmentRule {
 		Src: discovery_kit_api.SourceOrDestination{
 			Type: TargetIDVM,
 			Selector: map[string]string{
-				"gcp-vm.hostname": "${dest.container.host}",
+				attrVmHostname: "${dest.container.host}",
 			},
 		},
 		Dest: discovery_kit_api.SourceOrDestination{
 			Type: "com.steadybit.extension_container.container",
 			Selector: map[string]string{
-				"container.host": "${src.gcp-vm.hostname}",
+				"container.host": enrichSrcHostname,
 			},
 		},
 		Attributes: []discovery_kit_api.Attribute{
 			{
 				Matcher: discovery_kit_api.StartsWith,
-				Name:    "gcp-vm.label.",
+				Name:    attrPrefixVmLabel,
 			},
 			{
 				Matcher: discovery_kit_api.StartsWith,
-				Name:    "gcp-vm.",
+				Name:    attrPrefixVm,
 			},
 			{
 				Matcher: discovery_kit_api.StartsWith,
-				Name:    "gcp-kubernetes-engine.",
+				Name:    attrPrefixGKE,
 			},
 			{
 				Matcher: discovery_kit_api.Equals,
-				Name:    "gcp.zone",
+				Name:    attrZone,
 			},
 			{
 				Matcher: discovery_kit_api.Equals,
-				Name:    "gcp.project.id",
+				Name:    attrProjectID,
 			},
 		},
 	}
@@ -481,23 +481,23 @@ func getVMToXEnrichmentRule(destTargetType string) discovery_kit_api.TargetEnric
 		Src: discovery_kit_api.SourceOrDestination{
 			Type: TargetIDVM,
 			Selector: map[string]string{
-				"gcp-vm.hostname": "${dest.host.hostname}",
+				attrVmHostname: "${dest.host.hostname}",
 			},
 		},
 		Dest: discovery_kit_api.SourceOrDestination{
 			Type: destTargetType,
 			Selector: map[string]string{
-				"host.hostname": "${src.gcp-vm.hostname}",
+				"host.hostname": enrichSrcHostname,
 			},
 		},
 		Attributes: []discovery_kit_api.Attribute{
 			{
 				Matcher: discovery_kit_api.Equals,
-				Name:    "gcp.zone",
+				Name:    attrZone,
 			},
 			{
 				Matcher: discovery_kit_api.Equals,
-				Name:    "gcp.project.id",
+				Name:    attrProjectID,
 			},
 		},
 	}


### PR DESCRIPTION
## Summary

Two follow-ups to close the remaining Sonar findings on \`main\`:

- **extvm/vm_discovery.go (10 × \`go:S1192\`)** — pre-existing file that batch A (#361) explicitly skipped. Same pattern applied: 10 attribute-name literals extracted into per-package const block in \`common.go\`.
- **extnat/nat_attack_disassociate.go (1 × \`go:S3776\`)** — \`Prepare\` measured cognitive complexity 17 (after the correctness fixes in #363). Split into three helpers (\`populatePrepareTarget\`, \`fetchRouter\`, \`snapshotNatSubnetworks\`), \`Prepare\` is now sequential delegation.

Zero behavioural change. \`go build ./...\` / \`go vet ./...\` / \`go test ./...\` all clean.

## Sonar impact

After merge, expected new-code state on \`main\`:
- \`go:S1192\`: 10 → 0
- \`go:S3776\`: 1 → 0 (PR #362 closes the other 10 when it merges)
- Remaining: only pre-existing scaffold lints in \`Dockerfile\` + \`linuxpkg/scripts/*.sh\` (14) — same in every extension repo, best fixed upstream in \`extension-scaffold\`.

## Related

- Follows: #361 (batch A, merged), #363 (correctness fixes, merged)
- Sibling: #362 (batch B, still open; closes the other 10 S3776 issues)