### PR TITLE
test: add unit tests for PR #334 packages to raise coverage

### DIFF
--- a/extcloudrun/service_discovery_test.go
+++ b/extcloudrun/service_discovery_test.go
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2026 steadybit GmbH. All rights reserved.
+ */
+
+package extcloudrun
+
+import (
+	"testing"
+	"time"
+
+	"cloud.google.com/go/run/apiv2/runpb"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/types/known/durationpb"
+)
+
+func TestParseServiceName(t *testing.T) {
+	loc, name := parseServiceName("projects/my-proj/locations/europe-west1/services/my-svc")
+	assert.Equal(t, "europe-west1", loc)
+	assert.Equal(t, "my-svc", name)
+
+	loc, name = parseServiceName("not-a-valid-name")
+	assert.Equal(t, "", loc)
+	assert.Equal(t, "", name)
+}
+
+func TestToServiceTarget_Populated(t *testing.T) {
+	svc := &runpb.Service{
+		Name:               "projects/proj-a/locations/europe-west1/services/svc-a",
+		Ingress:            runpb.IngressTraffic_INGRESS_TRAFFIC_ALL,
+		LaunchStage:        1, // LAUNCH_STAGE_UNSPECIFIED is 0; use 1 to avoid the "skip if zero" guard
+		InvokerIamDisabled: true,
+		IapEnabled:         true,
+		Scaling: &runpb.ServiceScaling{
+			MinInstanceCount: 2,
+			ScalingMode:      runpb.ServiceScaling_AUTOMATIC,
+		},
+		Template: &runpb.RevisionTemplate{
+			MaxInstanceRequestConcurrency: 42,
+			Timeout:                       durationpb.New(60 * time.Second),
+			ServiceAccount:                "sa@proj-a.iam.gserviceaccount.com",
+			Scaling: &runpb.RevisionScaling{
+				MinInstanceCount: 1,
+				MaxInstanceCount: 5,
+			},
+		},
+		Urls: []string{"https://svc-a-xyz.a.run.app"},
+		Labels: map[string]string{
+			"team": "core",
+		},
+	}
+	target := toServiceTarget(svc, "proj-a")
+
+	assert.Equal(t, TargetIDService, target.TargetType)
+	assert.Equal(t, "svc-a", target.Label)
+	assert.Equal(t, "projects/proj-a/locations/europe-west1/services/svc-a", target.Id)
+	assert.Equal(t, []string{"proj-a"}, target.Attributes[attrProjectID])
+	assert.Equal(t, []string{"svc-a"}, target.Attributes["gcp.cloudrun.service.name"])
+	assert.Equal(t, []string{"europe-west1"}, target.Attributes[attrLocation])
+	assert.Equal(t, []string{"INGRESS_TRAFFIC_ALL"}, target.Attributes[attrIngress])
+	assert.Contains(t, target.Attributes, "gcp.cloudrun.service.launch-stage")
+	assert.Equal(t, []string{"true"}, target.Attributes["gcp.cloudrun.service.invoker-iam-disabled"])
+	assert.Equal(t, []string{"true"}, target.Attributes["gcp.cloudrun.service.iap-enabled"])
+	assert.Equal(t, []string{"2"}, target.Attributes["gcp.cloudrun.service.scaling.min-instance-count"])
+	assert.Equal(t, []string{"AUTOMATIC"}, target.Attributes["gcp.cloudrun.service.scaling.scaling-mode"])
+	assert.Equal(t, []string{"42"}, target.Attributes["gcp.cloudrun.service.template.max-instance-request-concurrency"])
+	assert.Equal(t, []string{"1m0s"}, target.Attributes["gcp.cloudrun.service.template.timeout"])
+	assert.Equal(t, []string{"sa@proj-a.iam.gserviceaccount.com"}, target.Attributes["gcp.cloudrun.service.template.service-account"])
+	assert.Equal(t, []string{"1"}, target.Attributes["gcp.cloudrun.service.template.scaling.min-instance-count"])
+	assert.Equal(t, []string{"5"}, target.Attributes["gcp.cloudrun.service.template.scaling.max-instance-count"])
+	assert.Equal(t, []string{"https://svc-a-xyz.a.run.app"}, target.Attributes["gcp.cloudrun.service.urls"])
+	assert.Equal(t, []string{"core"}, target.Attributes["gcp.cloudrun.service.label.team"])
+}
+
+func TestToServiceTarget_Sparse(t *testing.T) {
+	svc := &runpb.Service{
+		Name: "projects/proj-a/locations/europe-west1/services/svc-b",
+	}
+	target := toServiceTarget(svc, "proj-a")
+
+	assert.Equal(t, "svc-b", target.Label)
+	// Ingress/LaunchStage unset -> not present
+	assert.NotContains(t, target.Attributes, attrIngress)
+	assert.NotContains(t, target.Attributes, "gcp.cloudrun.service.launch-stage")
+	// Scaling nil -> min-instance-count absent
+	assert.NotContains(t, target.Attributes, "gcp.cloudrun.service.scaling.min-instance-count")
+	// Template nil -> no template attrs
+	assert.NotContains(t, target.Attributes, "gcp.cloudrun.service.template.timeout")
+	assert.NotContains(t, target.Attributes, "gcp.cloudrun.service.urls")
+	// InvokerIamDisabled/IapEnabled are always emitted (default false)
+	assert.Equal(t, []string{"false"}, target.Attributes["gcp.cloudrun.service.invoker-iam-disabled"])
+	assert.Equal(t, []string{"false"}, target.Attributes["gcp.cloudrun.service.iap-enabled"])
+}
+
+func TestDescribeMethods(t *testing.T) {
+	d := &serviceDiscovery{}
+	desc := d.Describe()
+	assert.Equal(t, TargetIDService, desc.Id)
+	target := d.DescribeTarget()
+	assert.Equal(t, TargetIDService, target.Id)
+	attrs := d.DescribeAttributes()
+	assert.NotEmpty(t, attrs)
+}
+
+func TestNewServiceDiscovery(t *testing.T) {
+	d := NewServiceDiscovery()
+	assert.NotNil(t, d)
+}

--- a/extcloudsql/instance_attack_failover_test.go
+++ b/extcloudsql/instance_attack_failover_test.go
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2026 steadybit GmbH. All rights reserved.
+ */
+
+package extcloudsql
+
+import (
+	"context"
+	"testing"
+
+	"github.com/steadybit/action-kit/go/action_kit_api/v2"
+	"github.com/steadybit/extension-kit/extutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCloudSqlFailover_Prepare_Success(t *testing.T) {
+	a := &cloudSqlFailoverAttack{}
+	state := CloudSqlFailoverState{}
+	req := extutil.JsonMangle(action_kit_api.PrepareActionRequestBody{
+		Target: extutil.Ptr(action_kit_api.Target{
+			Attributes: map[string][]string{
+				"gcp.project.id":                  {"proj-a"},
+				"gcp.cloudsql.instance.name":      {"primary"},
+				"gcp.cloudsql.availability-type":  {"REGIONAL"},
+			},
+		}),
+	})
+	res, err := a.Prepare(context.Background(), &state, req)
+	require.NoError(t, err)
+	assert.Nil(t, res)
+	assert.Equal(t, "proj-a", state.ProjectID)
+	assert.Equal(t, "primary", state.InstanceName)
+}
+
+func TestCloudSqlFailover_Prepare_MissingProjectID(t *testing.T) {
+	a := &cloudSqlFailoverAttack{}
+	state := CloudSqlFailoverState{}
+	req := extutil.JsonMangle(action_kit_api.PrepareActionRequestBody{
+		Target: extutil.Ptr(action_kit_api.Target{
+			Attributes: map[string][]string{
+				"gcp.cloudsql.instance.name":     {"primary"},
+				"gcp.cloudsql.availability-type": {"REGIONAL"},
+			},
+		}),
+	})
+	_, err := a.Prepare(context.Background(), &state, req)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "gcp.project.id")
+}
+
+func TestCloudSqlFailover_Prepare_NonRegionalRejected(t *testing.T) {
+	a := &cloudSqlFailoverAttack{}
+	state := CloudSqlFailoverState{}
+	req := extutil.JsonMangle(action_kit_api.PrepareActionRequestBody{
+		Target: extutil.Ptr(action_kit_api.Target{
+			Attributes: map[string][]string{
+				"gcp.project.id":                 {"proj-a"},
+				"gcp.cloudsql.instance.name":     {"primary"},
+				"gcp.cloudsql.availability-type": {"ZONAL"},
+			},
+		}),
+	})
+	_, err := a.Prepare(context.Background(), &state, req)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "REGIONAL")
+}
+
+func TestCloudSqlFailover_Prepare_MissingAvailabilityType(t *testing.T) {
+	a := &cloudSqlFailoverAttack{}
+	state := CloudSqlFailoverState{}
+	req := extutil.JsonMangle(action_kit_api.PrepareActionRequestBody{
+		Target: extutil.Ptr(action_kit_api.Target{
+			Attributes: map[string][]string{
+				"gcp.project.id":             {"proj-a"},
+				"gcp.cloudsql.instance.name": {"primary"},
+			},
+		}),
+	})
+	_, err := a.Prepare(context.Background(), &state, req)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "REGIONAL")
+}
+
+func TestCloudSqlFailover_Describe(t *testing.T) {
+	a := &cloudSqlFailoverAttack{}
+	desc := a.Describe()
+	assert.Equal(t, InstanceFailoverActionId, desc.Id)
+	assert.Equal(t, TargetIDInstance, desc.TargetSelection.TargetType)
+	assert.Equal(t, CloudSqlFailoverState{}, a.NewEmptyState())
+}
+
+func TestCloudSqlFailover_NewInstanceFailoverAction(t *testing.T) {
+	a := NewInstanceFailoverAction()
+	assert.NotNil(t, a)
+}
+
+func TestMustHave(t *testing.T) {
+	attrs := map[string][]string{
+		"present": {"value"},
+		"empty":   {},
+	}
+	assert.Equal(t, "value", mustHave(attrs, "present"))
+	assert.Equal(t, "", mustHave(attrs, "missing"))
+	assert.Equal(t, "", mustHave(attrs, "empty"))
+}

--- a/extcloudsql/instance_discovery_test.go
+++ b/extcloudsql/instance_discovery_test.go
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2026 steadybit GmbH. All rights reserved.
+ */
+
+package extcloudsql
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/api/sqladmin/v1"
+)
+
+func TestToInstanceTarget_Populated(t *testing.T) {
+	inst := &sqladmin.DatabaseInstance{
+		Name:             "primary",
+		DatabaseVersion:  "POSTGRES_15",
+		Region:           "europe-west1",
+		GceZone:          "europe-west1-a",
+		SecondaryGceZone: "europe-west1-b",
+		State:            "RUNNABLE",
+		InstanceType:     "CLOUD_SQL_INSTANCE",
+		Settings: &sqladmin.Settings{
+			Tier:             "db-custom-2-7680",
+			AvailabilityType: "REGIONAL",
+			BackupConfiguration: &sqladmin.BackupConfiguration{
+				Enabled:                    true,
+				PointInTimeRecoveryEnabled: true,
+			},
+			DeletionProtectionEnabled: true,
+			IpConfiguration: &sqladmin.IpConfiguration{
+				Ipv4Enabled:    false,
+				PrivateNetwork: "projects/proj/global/networks/default",
+				RequireSsl:     true,
+			},
+			DataDiskType:   "PD_SSD",
+			DataDiskSizeGb: 100,
+			MaintenanceWindow: &sqladmin.MaintenanceWindow{
+				Day: 3,
+			},
+			UserLabels: map[string]string{"team": "core"},
+		},
+	}
+
+	target := toInstanceTarget(inst, "proj-a")
+
+	assert.Equal(t, TargetIDInstance, target.TargetType)
+	assert.Equal(t, "primary", target.Label)
+	assert.Equal(t, "projects/proj-a/instances/primary", target.Id)
+	assert.Equal(t, []string{"proj-a"}, target.Attributes["gcp.project.id"])
+	assert.Equal(t, []string{"primary"}, target.Attributes["gcp.cloudsql.instance.name"])
+	assert.Equal(t, []string{"POSTGRES_15"}, target.Attributes[attrDatabaseVersion])
+	assert.Equal(t, []string{"europe-west1"}, target.Attributes[attrRegion])
+	assert.Equal(t, []string{"europe-west1-a"}, target.Attributes["gcp.cloudsql.gce-zone"])
+	assert.Equal(t, []string{"europe-west1-b"}, target.Attributes["gcp.cloudsql.secondary-gce-zone"])
+	assert.Equal(t, []string{"RUNNABLE"}, target.Attributes["gcp.cloudsql.state"])
+	assert.Equal(t, []string{"CLOUD_SQL_INSTANCE"}, target.Attributes["gcp.cloudsql.instance-type"])
+	assert.Equal(t, []string{"db-custom-2-7680"}, target.Attributes[attrTier])
+	assert.Equal(t, []string{"REGIONAL"}, target.Attributes[attrAvailabilityType])
+	assert.Equal(t, []string{"true"}, target.Attributes["gcp.cloudsql.backup-enabled"])
+	assert.Equal(t, []string{"true"}, target.Attributes["gcp.cloudsql.point-in-time-recovery-enabled"])
+	assert.Equal(t, []string{"true"}, target.Attributes["gcp.cloudsql.deletion-protection-enabled"])
+	assert.Equal(t, []string{"false"}, target.Attributes["gcp.cloudsql.public-network-access"])
+	assert.Equal(t, []string{"projects/proj/global/networks/default"}, target.Attributes["gcp.cloudsql.private-network"])
+	assert.Equal(t, []string{"true"}, target.Attributes["gcp.cloudsql.require-ssl"])
+	assert.Equal(t, []string{"PD_SSD"}, target.Attributes["gcp.cloudsql.disk-type"])
+	assert.Equal(t, []string{"100"}, target.Attributes["gcp.cloudsql.disk-size-gb"])
+	assert.Equal(t, []string{"3"}, target.Attributes["gcp.cloudsql.maintenance-window.day"])
+	assert.Equal(t, []string{"core"}, target.Attributes["gcp.cloudsql.label.team"])
+}
+
+func TestToInstanceTarget_Sparse(t *testing.T) {
+	inst := &sqladmin.DatabaseInstance{
+		Name: "sparse",
+	}
+	target := toInstanceTarget(inst, "proj-a")
+
+	assert.Equal(t, "sparse", target.Label)
+	assert.NotContains(t, target.Attributes, attrDatabaseVersion)
+	assert.NotContains(t, target.Attributes, attrRegion)
+	assert.NotContains(t, target.Attributes, "gcp.cloudsql.gce-zone")
+	assert.NotContains(t, target.Attributes, "gcp.cloudsql.state")
+	assert.NotContains(t, target.Attributes, attrTier)
+	assert.NotContains(t, target.Attributes, "gcp.cloudsql.deletion-protection-enabled")
+	assert.NotContains(t, target.Attributes, "gcp.cloudsql.disk-size-gb")
+	assert.NotContains(t, target.Attributes, "gcp.cloudsql.maintenance-window.day")
+}
+
+func TestToInstanceTarget_SettingsWithoutBackupOrIpConfig(t *testing.T) {
+	inst := &sqladmin.DatabaseInstance{
+		Name: "primary",
+		Settings: &sqladmin.Settings{
+			Tier: "db-custom-2-7680",
+		},
+	}
+	target := toInstanceTarget(inst, "proj-a")
+
+	assert.Equal(t, []string{"db-custom-2-7680"}, target.Attributes[attrTier])
+	// DeletionProtectionEnabled is always set from settings when settings present
+	assert.Equal(t, []string{"false"}, target.Attributes["gcp.cloudsql.deletion-protection-enabled"])
+	assert.NotContains(t, target.Attributes, "gcp.cloudsql.backup-enabled")
+	assert.NotContains(t, target.Attributes, "gcp.cloudsql.public-network-access")
+}
+
+func TestDescribeMethods(t *testing.T) {
+	d := &instanceDiscovery{}
+	assert.Equal(t, TargetIDInstance, d.Describe().Id)
+	assert.Equal(t, TargetIDInstance, d.DescribeTarget().Id)
+	assert.NotEmpty(t, d.DescribeAttributes())
+}
+
+func TestNewInstanceDiscovery(t *testing.T) {
+	d := NewInstanceDiscovery()
+	assert.NotNil(t, d)
+}

--- a/extdisk/disk_discovery_test.go
+++ b/extdisk/disk_discovery_test.go
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2026 steadybit GmbH. All rights reserved.
+ */
+
+package extdisk
+
+import (
+	"testing"
+
+	"cloud.google.com/go/compute/apiv1/computepb"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestClassifyScope(t *testing.T) {
+	z, r := classifyScope("zones/europe-west1-a")
+	assert.Equal(t, "europe-west1-a", z)
+	assert.Equal(t, "", r)
+
+	z, r = classifyScope("regions/europe-west1")
+	assert.Equal(t, "", z)
+	assert.Equal(t, "europe-west1", r)
+
+	z, r = classifyScope("global")
+	assert.Equal(t, "", z)
+	assert.Equal(t, "", r)
+}
+
+func TestToDiskTarget_Populated(t *testing.T) {
+	disk := &computepb.Disk{
+		Name:                   ptr("my-disk"),
+		SelfLink:               ptr("https://www.googleapis.com/compute/v1/projects/proj-a/zones/europe-west1-a/disks/my-disk"),
+		Type:                   ptr("https://www.googleapis.com/compute/v1/projects/proj-a/zones/europe-west1-a/diskTypes/pd-ssd"),
+		SizeGb:                 ptrInt64(100),
+		Status:                 ptr("READY"),
+		Users:                  []string{"z-user", "a-user"},
+		SourceImage:            ptr("projects/img/global/images/family/x"),
+		SourceSnapshot:         ptr("projects/snap"),
+		DiskEncryptionKey:      &computepb.CustomerEncryptionKey{KmsKeyName: ptr("projects/kms/keys/x")},
+		PhysicalBlockSizeBytes: ptrInt64(4096),
+		ProvisionedIops:        ptrInt64(3000),
+		ProvisionedThroughput:  ptrInt64(200),
+		Architecture:           ptr("X86_64"),
+		Labels:                 map[string]string{"team": "core"},
+	}
+	target := toDiskTarget(disk, "europe-west1-a", "", "proj-a")
+
+	assert.Equal(t, TargetIDDisk, target.TargetType)
+	assert.Equal(t, "my-disk", target.Label)
+	assert.Equal(t, "https://www.googleapis.com/compute/v1/projects/proj-a/zones/europe-west1-a/disks/my-disk", target.Id)
+	assert.Equal(t, []string{"proj-a"}, target.Attributes[attrProjectID])
+	assert.Equal(t, []string{"my-disk"}, target.Attributes["gcp.persistent-disk.name"])
+	assert.Equal(t, []string{"europe-west1-a"}, target.Attributes[attrZone])
+	assert.Equal(t, []string{"pd-ssd"}, target.Attributes[attrType])
+	assert.Equal(t, []string{"100"}, target.Attributes[attrSizeGB])
+	assert.Equal(t, []string{"READY"}, target.Attributes["gcp.persistent-disk.status"])
+	assert.Equal(t, []string{"a-user", "z-user"}, target.Attributes["gcp.persistent-disk.users"])
+	assert.Equal(t, []string{"projects/img/global/images/family/x"}, target.Attributes["gcp.persistent-disk.source-image"])
+	assert.Equal(t, []string{"projects/snap"}, target.Attributes["gcp.persistent-disk.source-snapshot"])
+	assert.Equal(t, []string{"projects/kms/keys/x"}, target.Attributes["gcp.persistent-disk.kms-key-name"])
+	assert.Equal(t, []string{"4096"}, target.Attributes["gcp.persistent-disk.physical-block-size-bytes"])
+	assert.Equal(t, []string{"3000"}, target.Attributes["gcp.persistent-disk.provisioned-iops"])
+	assert.Equal(t, []string{"200"}, target.Attributes["gcp.persistent-disk.provisioned-throughput"])
+	assert.Equal(t, []string{"X86_64"}, target.Attributes["gcp.persistent-disk.architecture"])
+	assert.Equal(t, []string{"core"}, target.Attributes["gcp.persistent-disk.label.team"])
+}
+
+func TestToDiskTarget_RegionalNoTypeUrl(t *testing.T) {
+	disk := &computepb.Disk{
+		Name: ptr("regional"),
+		Type: ptr("pd-standard"), // no slash in URL
+	}
+	target := toDiskTarget(disk, "", "europe-west1", "proj-a")
+
+	assert.NotContains(t, target.Attributes, attrZone)
+	assert.Equal(t, []string{"europe-west1"}, target.Attributes["gcp.persistent-disk.region"])
+	assert.Equal(t, []string{"pd-standard"}, target.Attributes[attrType])
+}
+
+func TestToDiskTarget_Sparse(t *testing.T) {
+	disk := &computepb.Disk{
+		Name: ptr("sparse"),
+	}
+	target := toDiskTarget(disk, "", "", "proj-a")
+
+	assert.Equal(t, "sparse", target.Label)
+	assert.NotContains(t, target.Attributes, attrZone)
+	assert.NotContains(t, target.Attributes, "gcp.persistent-disk.region")
+	assert.NotContains(t, target.Attributes, attrType)
+	assert.NotContains(t, target.Attributes, attrSizeGB)
+	assert.NotContains(t, target.Attributes, "gcp.persistent-disk.status")
+	assert.NotContains(t, target.Attributes, "gcp.persistent-disk.users")
+	assert.NotContains(t, target.Attributes, "gcp.persistent-disk.kms-key-name")
+}
+
+func TestDescribeMethods(t *testing.T) {
+	d := &diskDiscovery{}
+	assert.Equal(t, TargetIDDisk, d.Describe().Id)
+	assert.Equal(t, TargetIDDisk, d.DescribeTarget().Id)
+	assert.NotEmpty(t, d.DescribeAttributes())
+}
+
+func TestNewDiskDiscovery(t *testing.T) {
+	assert.NotNil(t, NewDiskDiscovery())
+}
+
+func ptr[T any](v T) *T { return &v }
+func ptrInt64(v int64) *int64 {
+	return &v
+}

--- a/extgke/cluster_discovery_test.go
+++ b/extgke/cluster_discovery_test.go
@@ -1,0 +1,223 @@
+/*
+ * Copyright 2026 steadybit GmbH. All rights reserved.
+ */
+
+package extgke
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"cloud.google.com/go/container/apiv1/containerpb"
+	"github.com/googleapis/gax-go/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClassifyLocation(t *testing.T) {
+	assert.Equal(t, "zonal", classifyLocation("us-central1-a"))
+	assert.Equal(t, "zonal", classifyLocation("europe-west1-b"))
+	assert.Equal(t, "regional", classifyLocation("us-central1"))
+	assert.Equal(t, "regional", classifyLocation("europe-west1"))
+	// No dash at all -> regional (default)
+	assert.Equal(t, "regional", classifyLocation("nowhere"))
+}
+
+func TestToClusterTarget_Populated(t *testing.T) {
+	c := &containerpb.Cluster{
+		Name:                 "my-cluster",
+		Location:             "us-central1",
+		CurrentMasterVersion: "1.28.3-gke.1286000",
+		Status:               containerpb.Cluster_RUNNING,
+		ReleaseChannel:       &containerpb.ReleaseChannel{Channel: containerpb.ReleaseChannel_REGULAR},
+		LoggingService:       "logging.googleapis.com/kubernetes",
+		MonitoringService:    "monitoring.googleapis.com/kubernetes",
+		Network:              "default",
+		Subnetwork:           "default-subnet",
+		Locations:            []string{"us-central1-b", "us-central1-a"},
+		PrivateClusterConfig: &containerpb.PrivateClusterConfig{
+			EnablePrivateNodes:    true,
+			EnablePrivateEndpoint: false,
+		},
+		MasterAuthorizedNetworksConfig: &containerpb.MasterAuthorizedNetworksConfig{
+			Enabled: true,
+			CidrBlocks: []*containerpb.MasterAuthorizedNetworksConfig_CidrBlock{
+				{CidrBlock: "10.0.0.0/8"},
+				{CidrBlock: ""},
+			},
+		},
+		WorkloadIdentityConfig: &containerpb.WorkloadIdentityConfig{
+			WorkloadPool: "proj-a.svc.id.goog",
+		},
+		ShieldedNodes:       &containerpb.ShieldedNodes{Enabled: true},
+		BinaryAuthorization: &containerpb.BinaryAuthorization{EvaluationMode: containerpb.BinaryAuthorization_PROJECT_SINGLETON_POLICY_ENFORCE},
+		ResourceLabels:      map[string]string{"env": "prod"},
+	}
+	target := toClusterTarget(c, "proj-a")
+
+	assert.Equal(t, TargetIDCluster, target.TargetType)
+	assert.Equal(t, "my-cluster", target.Label)
+	assert.Equal(t, "projects/proj-a/locations/us-central1/clusters/my-cluster", target.Id)
+	assert.Equal(t, []string{"proj-a"}, target.Attributes[attrProjectID])
+	assert.Equal(t, []string{"my-cluster"}, target.Attributes[attrClusterName])
+	assert.Equal(t, []string{"us-central1"}, target.Attributes[attrClusterLocation])
+	assert.Equal(t, []string{"regional"}, target.Attributes[attrClusterLocationType])
+	assert.Equal(t, []string{"my-cluster"}, target.Attributes[attrK8sClusterName])
+	assert.Equal(t, []string{"1.28.3-gke.1286000"}, target.Attributes[attrClusterKubernetesVersion])
+	assert.Equal(t, []string{"RUNNING"}, target.Attributes["gcp.gke.cluster.status"])
+	assert.Equal(t, []string{"REGULAR"}, target.Attributes[attrClusterReleaseChannel])
+	assert.Equal(t, []string{"logging.googleapis.com/kubernetes"}, target.Attributes[attrClusterLoggingService])
+	assert.Equal(t, []string{"monitoring.googleapis.com/kubernetes"}, target.Attributes[attrClusterMonitoringService])
+	assert.Equal(t, []string{"default"}, target.Attributes[attrClusterNetwork])
+	assert.Equal(t, []string{"default-subnet"}, target.Attributes[attrClusterSubnetwork])
+	assert.Equal(t, []string{"us-central1-a", "us-central1-b"}, target.Attributes["gcp.gke.cluster.node-locations"])
+	assert.Equal(t, []string{"true"}, target.Attributes[attrClusterPrivateCluster])
+	assert.Equal(t, []string{"true"}, target.Attributes[attrClusterMasterAuthorizedNetsEnabled])
+	assert.Equal(t, []string{"10.0.0.0/8"}, target.Attributes[attrClusterMasterAuthorizedNetsCidrs])
+	// MAN enabled AND restricted -> API not open to internet
+	assert.Equal(t, []string{"false"}, target.Attributes[attrClusterApiServerOpenToInternet])
+	assert.Equal(t, []string{"true"}, target.Attributes[attrClusterWorkloadIdentityEnabled])
+	assert.Equal(t, []string{"true"}, target.Attributes[attrClusterShieldedNodesEnabled])
+	assert.Equal(t, []string{"PROJECT_SINGLETON_POLICY_ENFORCE"}, target.Attributes[attrClusterBinaryAuthEvalMode])
+	assert.Equal(t, []string{"prod"}, target.Attributes["gcp.gke.cluster.label.env"])
+}
+
+func TestToClusterTarget_Sparse(t *testing.T) {
+	c := &containerpb.Cluster{
+		Name:     "sparse",
+		Location: "us-central1-a",
+	}
+	target := toClusterTarget(c, "proj-a")
+
+	assert.Equal(t, "sparse", target.Label)
+	assert.Equal(t, []string{"zonal"}, target.Attributes[attrClusterLocationType])
+	// PrivateClusterConfig nil -> private-cluster is false
+	assert.Equal(t, []string{"false"}, target.Attributes[attrClusterPrivateCluster])
+	// MAN disabled: no CIDRs -> not restricted -> API open to internet true
+	assert.Equal(t, []string{"true"}, target.Attributes[attrClusterApiServerOpenToInternet])
+	// Absent: kubernetes version, status, release channel, logging, monitoring
+	assert.NotContains(t, target.Attributes, attrClusterKubernetesVersion)
+	assert.NotContains(t, target.Attributes, "gcp.gke.cluster.status")
+	assert.NotContains(t, target.Attributes, attrClusterReleaseChannel)
+	assert.NotContains(t, target.Attributes, attrClusterLoggingService)
+	// WorkloadIdentity absent -> false
+	assert.Equal(t, []string{"false"}, target.Attributes[attrClusterWorkloadIdentityEnabled])
+	assert.Equal(t, []string{"false"}, target.Attributes[attrClusterShieldedNodesEnabled])
+}
+
+func TestToClusterTarget_ManDisabledButHasCidrs_NotMisreportedAsRestricted(t *testing.T) {
+	// MAN disabled AND has non-wildcard leftover CIDR: must NOT be reported as restricted (API open = true)
+	c := &containerpb.Cluster{
+		Name:     "c",
+		Location: "us-central1",
+		MasterAuthorizedNetworksConfig: &containerpb.MasterAuthorizedNetworksConfig{
+			Enabled: false,
+			CidrBlocks: []*containerpb.MasterAuthorizedNetworksConfig_CidrBlock{
+				{CidrBlock: "10.0.0.0/8"},
+			},
+		},
+	}
+	target := toClusterTarget(c, "proj-a")
+	assert.Equal(t, []string{"false"}, target.Attributes[attrClusterMasterAuthorizedNetsEnabled])
+	// MAN disabled -> not restricted -> API server open to internet
+	assert.Equal(t, []string{"true"}, target.Attributes[attrClusterApiServerOpenToInternet])
+}
+
+func TestToClusterTarget_ManEnabledOnlyWildcard_ReportsOpen(t *testing.T) {
+	c := &containerpb.Cluster{
+		Name:     "c",
+		Location: "us-central1",
+		MasterAuthorizedNetworksConfig: &containerpb.MasterAuthorizedNetworksConfig{
+			Enabled: true,
+			CidrBlocks: []*containerpb.MasterAuthorizedNetworksConfig_CidrBlock{
+				{CidrBlock: "0.0.0.0/0"},
+			},
+		},
+	}
+	target := toClusterTarget(c, "proj-a")
+	assert.Equal(t, []string{"true"}, target.Attributes[attrClusterMasterAuthorizedNetsEnabled])
+	// Only 0.0.0.0/0 -> not restricted -> open true
+	assert.Equal(t, []string{"true"}, target.Attributes[attrClusterApiServerOpenToInternet])
+}
+
+func TestToClusterTarget_PrivateEndpoint_ReportsNotOpen(t *testing.T) {
+	c := &containerpb.Cluster{
+		Name:     "c",
+		Location: "us-central1",
+		PrivateClusterConfig: &containerpb.PrivateClusterConfig{
+			EnablePrivateNodes:    true,
+			EnablePrivateEndpoint: true,
+		},
+	}
+	target := toClusterTarget(c, "proj-a")
+	assert.Equal(t, []string{"false"}, target.Attributes[attrClusterApiServerOpenToInternet])
+}
+
+func TestClusterDiscovery_DescribeMethods(t *testing.T) {
+	d := &clusterDiscovery{}
+	assert.Equal(t, TargetIDCluster, d.Describe().Id)
+	assert.Equal(t, TargetIDCluster, d.DescribeTarget().Id)
+	assert.NotEmpty(t, d.DescribeAttributes())
+	rules := d.DescribeEnrichmentRules()
+	assert.NotEmpty(t, rules)
+	// All target types should be covered
+	assert.Len(t, rules, len(gkeEnrichmentTargetTypes))
+}
+
+func TestNewClusterDiscovery(t *testing.T) {
+	assert.NotNil(t, NewClusterDiscovery())
+}
+
+func TestGkeClusterToK8sEnrichmentRule(t *testing.T) {
+	r := gkeClusterToK8sEnrichmentRule("com.steadybit.extension_kubernetes.kubernetes-node")
+	assert.Contains(t, r.Id, "cluster-to-com.steadybit.extension_kubernetes.kubernetes-node")
+	assert.Equal(t, TargetIDCluster, r.Src.Type)
+	assert.Equal(t, "com.steadybit.extension_kubernetes.kubernetes-node", r.Dest.Type)
+	assert.NotEmpty(t, r.Attributes)
+}
+
+// clusterManagerApiMock satisfies clusterManagerApi.
+type clusterManagerApiMock struct {
+	mock.Mock
+}
+
+func (m *clusterManagerApiMock) ListClusters(ctx context.Context, req *containerpb.ListClustersRequest, opts ...gax.CallOption) (*containerpb.ListClustersResponse, error) {
+	args := m.Called(ctx, req)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*containerpb.ListClustersResponse), args.Error(1)
+}
+
+func (m *clusterManagerApiMock) ListNodePools(ctx context.Context, req *containerpb.ListNodePoolsRequest, opts ...gax.CallOption) (*containerpb.ListNodePoolsResponse, error) {
+	args := m.Called(ctx, req)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*containerpb.ListNodePoolsResponse), args.Error(1)
+}
+
+func TestGetAllClusters(t *testing.T) {
+	m := &clusterManagerApiMock{}
+	m.On("ListClusters", mock.Anything, mock.Anything).Return(&containerpb.ListClustersResponse{
+		Clusters: []*containerpb.Cluster{
+			{Name: "c1", Location: "us-central1"},
+			{Name: "c2", Location: "us-central1-a"},
+		},
+	}, nil)
+
+	targets, err := getAllClusters(context.Background(), m, "proj-a")
+	require.NoError(t, err)
+	assert.Len(t, targets, 2)
+	m.AssertExpectations(t)
+}
+
+func TestGetAllClusters_Error(t *testing.T) {
+	m := &clusterManagerApiMock{}
+	m.On("ListClusters", mock.Anything, mock.Anything).Return(nil, errors.New("boom"))
+
+	_, err := getAllClusters(context.Background(), m, "proj-a")
+	require.Error(t, err)
+}

--- a/extgke/nodepool_attack_terminate_instances_test.go
+++ b/extgke/nodepool_attack_terminate_instances_test.go
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2026 steadybit GmbH. All rights reserved.
+ */
+
+package extgke
+
+import (
+	"context"
+	"testing"
+
+	"github.com/steadybit/action-kit/go/action_kit_api/v2"
+	"github.com/steadybit/extension-kit/extutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func gkePrepareReq(attrs map[string][]string, cfg map[string]interface{}) action_kit_api.PrepareActionRequestBody {
+	return extutil.JsonMangle(action_kit_api.PrepareActionRequestBody{
+		Target: extutil.Ptr(action_kit_api.Target{Attributes: attrs}),
+		Config: cfg,
+	})
+}
+
+var validNodePoolAttrs = map[string][]string{
+	"gcp.project.id":            {"proj-a"},
+	attrClusterName:             {"prod"},
+	"gcp.gke.nodepool.name":     {"default-pool"},
+	"gcp.gke.cluster.location":  {"europe-west1-b"},
+}
+
+func TestNodePoolTerminate_Prepare_MissingRequiredAttr(t *testing.T) {
+	for _, drop := range []string{"gcp.project.id", attrClusterName, "gcp.gke.nodepool.name", "gcp.gke.cluster.location"} {
+		attrs := map[string][]string{}
+		for k, v := range validNodePoolAttrs {
+			if k != drop {
+				attrs[k] = v
+			}
+		}
+		a := &nodePoolTerminateInstancesAttack{}
+		state := NodePoolTerminateInstancesState{}
+		_, err := a.Prepare(context.Background(), &state, gkePrepareReq(attrs, map[string]interface{}{"percentage": 33}))
+		require.Error(t, err, "dropping %s should fail Prepare", drop)
+		assert.Contains(t, err.Error(), "missing")
+	}
+}
+
+func TestNodePoolTerminate_Prepare_PercentageOutOfRange(t *testing.T) {
+	a := &nodePoolTerminateInstancesAttack{}
+	state := NodePoolTerminateInstancesState{}
+
+	_, err := a.Prepare(context.Background(), &state, gkePrepareReq(validNodePoolAttrs, map[string]interface{}{"percentage": 0}))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "percentage")
+
+	_, err = a.Prepare(context.Background(), &state, gkePrepareReq(validNodePoolAttrs, map[string]interface{}{"percentage": 101}))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "percentage")
+}
+
+func TestNodePoolTerminate_Prepare_HighImpactGate(t *testing.T) {
+	a := &nodePoolTerminateInstancesAttack{}
+	state := NodePoolTerminateInstancesState{}
+	_, err := a.Prepare(context.Background(), &state, gkePrepareReq(validNodePoolAttrs, map[string]interface{}{"percentage": 75}))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Allow percentages above 50%")
+}
+
+func TestParseZonalMIGUrl(t *testing.T) {
+	// Zonal URL — extract zone and name.
+	zone, name, ok := parseZonalMIGUrl("https://www.googleapis.com/compute/v1/projects/proj-a/zones/europe-west1-b/instanceGroupManagers/mig-1")
+	assert.True(t, ok)
+	assert.Equal(t, "europe-west1-b", zone)
+	assert.Equal(t, "mig-1", name)
+
+	// Regional URL — no /zones/ segment.
+	_, _, ok = parseZonalMIGUrl("https://www.googleapis.com/compute/v1/projects/proj-a/regions/europe-west1/instanceGroupManagers/rmig")
+	assert.False(t, ok)
+
+	// Malformed URL.
+	_, _, ok = parseZonalMIGUrl("garbage")
+	assert.False(t, ok)
+}
+
+func TestNodePoolTerminate_Describe(t *testing.T) {
+	a := &nodePoolTerminateInstancesAttack{}
+	desc := a.Describe()
+	assert.Equal(t, NodePoolTerminateInstancesActionId, desc.Id)
+	assert.Equal(t, TargetIDNodePool, desc.TargetSelection.TargetType)
+	assert.Equal(t, NodePoolTerminateInstancesState{}, a.NewEmptyState())
+}
+
+func TestNodePoolTerminate_NewAction(t *testing.T) {
+	a := NewNodePoolTerminateInstancesAction()
+	assert.NotNil(t, a)
+}
+
+func TestGkeMustHave(t *testing.T) {
+	attrs := map[string][]string{
+		"present": {"value"},
+		"empty":   {},
+	}
+	assert.Equal(t, "value", mustHave(attrs, "present"))
+	assert.Equal(t, "", mustHave(attrs, "missing"))
+	assert.Equal(t, "", mustHave(attrs, "empty"))
+}

--- a/extgke/nodepool_discovery_test.go
+++ b/extgke/nodepool_discovery_test.go
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2026 steadybit GmbH. All rights reserved.
+ */
+
+package extgke
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"cloud.google.com/go/container/apiv1/containerpb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestToNodePoolTarget_Populated(t *testing.T) {
+	cluster := &containerpb.Cluster{Name: "my-cluster", Location: "us-central1"}
+	np := &containerpb.NodePool{
+		Name:    "np-1",
+		Version: "1.28.3-gke.1286000",
+		Status:  containerpb.NodePool_RUNNING,
+		Config: &containerpb.NodeConfig{
+			MachineType: "e2-medium",
+			DiskType:    "pd-standard",
+			DiskSizeGb:  100,
+			ImageType:   "COS_CONTAINERD",
+			Preemptible: false,
+			Spot:        true,
+			Labels:      map[string]string{"team": "core"},
+		},
+		Autoscaling: &containerpb.NodePoolAutoscaling{
+			Enabled:      true,
+			MinNodeCount: 1,
+			MaxNodeCount: 5,
+		},
+		MaxPodsConstraint: &containerpb.MaxPodsConstraint{MaxPodsPerNode: 110},
+		Management:        &containerpb.NodeManagement{AutoUpgrade: true, AutoRepair: true},
+		UpgradeSettings:   &containerpb.NodePool_UpgradeSettings{MaxSurge: 1, MaxUnavailable: 0},
+		Locations:         []string{"us-central1-b", "us-central1-a"},
+		InstanceGroupUrls: []string{
+			"https://www.googleapis.com/compute/v1/projects/proj-a/zones/us-central1-b/instanceGroupManagers/gke-np-b",
+			"https://www.googleapis.com/compute/v1/projects/proj-a/zones/us-central1-a/instanceGroupManagers/gke-np-a",
+		},
+	}
+	target := toNodePoolTarget(np, cluster, "proj-a")
+
+	assert.Equal(t, TargetIDNodePool, target.TargetType)
+	assert.Equal(t, "my-cluster/np-1", target.Label)
+	assert.Equal(t, "projects/proj-a/locations/us-central1/clusters/my-cluster/nodePools/np-1", target.Id)
+	assert.Equal(t, []string{"proj-a"}, target.Attributes["gcp.project.id"])
+	assert.Equal(t, []string{"my-cluster"}, target.Attributes[attrClusterName])
+	assert.Equal(t, []string{"my-cluster"}, target.Attributes["k8s.cluster-name"])
+	assert.Equal(t, []string{"us-central1"}, target.Attributes["gcp.gke.cluster.location"])
+	assert.Equal(t, []string{"np-1"}, target.Attributes["gcp.gke.nodepool.name"])
+	assert.Equal(t, []string{"1.28.3-gke.1286000"}, target.Attributes[attrNodePoolKubernetesVersion])
+	assert.Equal(t, []string{"RUNNING"}, target.Attributes["gcp.gke.nodepool.status"])
+	assert.Equal(t, []string{"e2-medium"}, target.Attributes[attrNodePoolMachineType])
+	assert.Equal(t, []string{"pd-standard"}, target.Attributes["gcp.gke.nodepool.disk-type"])
+	assert.Equal(t, []string{"100"}, target.Attributes["gcp.gke.nodepool.disk-size-gb"])
+	assert.Equal(t, []string{"COS_CONTAINERD"}, target.Attributes["gcp.gke.nodepool.image-type"])
+	assert.Equal(t, []string{"false"}, target.Attributes["gcp.gke.nodepool.preemptible"])
+	assert.Equal(t, []string{"true"}, target.Attributes["gcp.gke.nodepool.spot"])
+	assert.Equal(t, []string{"true"}, target.Attributes[attrNodePoolAutoscalingEnabled])
+	assert.Equal(t, []string{"1"}, target.Attributes["gcp.gke.nodepool.autoscaling.min-node-count"])
+	assert.Equal(t, []string{"5"}, target.Attributes["gcp.gke.nodepool.autoscaling.max-node-count"])
+	assert.Equal(t, []string{"110"}, target.Attributes["gcp.gke.nodepool.max-pods-per-node"])
+	assert.Equal(t, []string{"true"}, target.Attributes["gcp.gke.nodepool.management.auto-upgrade"])
+	assert.Equal(t, []string{"true"}, target.Attributes["gcp.gke.nodepool.management.auto-repair"])
+	assert.Equal(t, []string{"1"}, target.Attributes["gcp.gke.nodepool.upgrade-settings.max-surge"])
+	assert.Equal(t, []string{"0"}, target.Attributes["gcp.gke.nodepool.upgrade-settings.max-unavailable"])
+	assert.Equal(t, []string{"us-central1-a", "us-central1-b"}, target.Attributes["gcp.gke.nodepool.locations"])
+	// Sorted URLs
+	urls := target.Attributes["gcp.gke.nodepool.instance-group-urls"]
+	assert.Len(t, urls, 2)
+	assert.Equal(t, urls[0], "https://www.googleapis.com/compute/v1/projects/proj-a/zones/us-central1-a/instanceGroupManagers/gke-np-a")
+	assert.Equal(t, []string{"core"}, target.Attributes["gcp.gke.nodepool.label.team"])
+}
+
+func TestToNodePoolTarget_Sparse(t *testing.T) {
+	cluster := &containerpb.Cluster{Name: "my-cluster", Location: "us-central1"}
+	np := &containerpb.NodePool{
+		Name: "empty",
+	}
+	target := toNodePoolTarget(np, cluster, "proj-a")
+
+	assert.Equal(t, "my-cluster/empty", target.Label)
+	// Autoscaling absent -> false
+	assert.Equal(t, []string{"false"}, target.Attributes[attrNodePoolAutoscalingEnabled])
+	assert.NotContains(t, target.Attributes, "gcp.gke.nodepool.autoscaling.min-node-count")
+	assert.NotContains(t, target.Attributes, "gcp.gke.nodepool.status")
+	assert.NotContains(t, target.Attributes, attrNodePoolMachineType)
+	assert.NotContains(t, target.Attributes, "gcp.gke.nodepool.image-type")
+	assert.NotContains(t, target.Attributes, "gcp.gke.nodepool.max-pods-per-node")
+	assert.NotContains(t, target.Attributes, "gcp.gke.nodepool.management.auto-upgrade")
+	assert.NotContains(t, target.Attributes, "gcp.gke.nodepool.locations")
+}
+
+func TestNodePoolDiscovery_DescribeMethods(t *testing.T) {
+	d := &nodePoolDiscovery{}
+	assert.Equal(t, TargetIDNodePool, d.Describe().Id)
+	assert.Equal(t, TargetIDNodePool, d.DescribeTarget().Id)
+	assert.NotEmpty(t, d.DescribeAttributes())
+}
+
+func TestNewNodePoolDiscovery(t *testing.T) {
+	assert.NotNil(t, NewNodePoolDiscovery())
+}
+
+func TestGetAllNodePools(t *testing.T) {
+	m := &clusterManagerApiMock{}
+	m.On("ListClusters", mock.Anything, mock.Anything).Return(&containerpb.ListClustersResponse{
+		Clusters: []*containerpb.Cluster{
+			{Name: "c1", Location: "us-central1"},
+		},
+	}, nil)
+	m.On("ListNodePools", mock.Anything, mock.Anything).Return(&containerpb.ListNodePoolsResponse{
+		NodePools: []*containerpb.NodePool{
+			{Name: "np-a"},
+			{Name: "np-b"},
+		},
+	}, nil)
+
+	targets, err := getAllNodePools(context.Background(), m, "proj-a")
+	require.NoError(t, err)
+	assert.Len(t, targets, 2)
+}
+
+func TestGetAllNodePools_ListClustersError(t *testing.T) {
+	m := &clusterManagerApiMock{}
+	m.On("ListClusters", mock.Anything, mock.Anything).Return(nil, errors.New("boom"))
+	_, err := getAllNodePools(context.Background(), m, "proj-a")
+	require.Error(t, err)
+}
+
+func TestGetAllNodePools_ListNodePoolsErrorSkipped(t *testing.T) {
+	m := &clusterManagerApiMock{}
+	m.On("ListClusters", mock.Anything, mock.Anything).Return(&containerpb.ListClustersResponse{
+		Clusters: []*containerpb.Cluster{
+			{Name: "c1", Location: "us-central1"},
+		},
+	}, nil)
+	m.On("ListNodePools", mock.Anything, mock.Anything).Return(nil, errors.New("boom"))
+
+	// Per-cluster errors are logged and skipped, not returned.
+	targets, err := getAllNodePools(context.Background(), m, "proj-a")
+	require.NoError(t, err)
+	assert.Empty(t, targets)
+}

--- a/extmemorystore/redis_attack_failover_test.go
+++ b/extmemorystore/redis_attack_failover_test.go
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2026 steadybit GmbH. All rights reserved.
+ */
+
+package extmemorystore
+
+import (
+	"context"
+	"testing"
+
+	"github.com/steadybit/action-kit/go/action_kit_api/v2"
+	"github.com/steadybit/extension-kit/extutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func redisReq(attrs map[string][]string, cfg map[string]interface{}) action_kit_api.PrepareActionRequestBody {
+	return extutil.JsonMangle(action_kit_api.PrepareActionRequestBody{
+		Target: extutil.Ptr(action_kit_api.Target{Attributes: attrs}),
+		Config: cfg,
+	})
+}
+
+var validRedisAttrs = map[string][]string{
+	"gcp.project.id":              {"proj-a"},
+	"gcp.memorystore.instance.id": {"cache-01"},
+	"gcp.memorystore.region":      {"europe-west1"},
+	attrTier:                      {"STANDARD_HA"},
+}
+
+func TestRedisFailover_Prepare_Success(t *testing.T) {
+	a := &redisFailoverAttack{}
+	state := RedisFailoverState{}
+	_, err := a.Prepare(context.Background(), &state, redisReq(validRedisAttrs, map[string]interface{}{"dataProtectionMode": "LIMITED_DATA_LOSS"}))
+	require.NoError(t, err)
+	assert.Equal(t, "proj-a", state.ProjectID)
+	assert.Equal(t, "cache-01", state.InstanceID)
+	assert.Equal(t, "projects/proj-a/locations/europe-west1/instances/cache-01", state.InstanceName)
+	assert.Equal(t, "LIMITED_DATA_LOSS", state.DataProtectionMode)
+}
+
+func TestRedisFailover_Prepare_ForceMode(t *testing.T) {
+	a := &redisFailoverAttack{}
+	state := RedisFailoverState{}
+	_, err := a.Prepare(context.Background(), &state, redisReq(validRedisAttrs, map[string]interface{}{"dataProtectionMode": "FORCE_DATA_LOSS"}))
+	require.NoError(t, err)
+	assert.Equal(t, "FORCE_DATA_LOSS", state.DataProtectionMode)
+}
+
+func TestRedisFailover_Prepare_MissingRequiredAttr(t *testing.T) {
+	for _, drop := range []string{"gcp.project.id", "gcp.memorystore.instance.id", "gcp.memorystore.region"} {
+		attrs := map[string][]string{}
+		for k, v := range validRedisAttrs {
+			if k != drop {
+				attrs[k] = v
+			}
+		}
+		a := &redisFailoverAttack{}
+		state := RedisFailoverState{}
+		_, err := a.Prepare(context.Background(), &state, redisReq(attrs, map[string]interface{}{"dataProtectionMode": "LIMITED_DATA_LOSS"}))
+		require.Error(t, err, "dropping %s should fail Prepare", drop)
+	}
+}
+
+func TestRedisFailover_Prepare_NonHATierRejected(t *testing.T) {
+	attrs := map[string][]string{}
+	for k, v := range validRedisAttrs {
+		attrs[k] = v
+	}
+	attrs[attrTier] = []string{"BASIC"}
+
+	a := &redisFailoverAttack{}
+	state := RedisFailoverState{}
+	_, err := a.Prepare(context.Background(), &state, redisReq(attrs, map[string]interface{}{"dataProtectionMode": "LIMITED_DATA_LOSS"}))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "STANDARD_HA")
+}
+
+func TestRedisFailover_Prepare_MissingTierRejected(t *testing.T) {
+	attrs := map[string][]string{}
+	for k, v := range validRedisAttrs {
+		if k != attrTier {
+			attrs[k] = v
+		}
+	}
+
+	a := &redisFailoverAttack{}
+	state := RedisFailoverState{}
+	_, err := a.Prepare(context.Background(), &state, redisReq(attrs, map[string]interface{}{"dataProtectionMode": "LIMITED_DATA_LOSS"}))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "STANDARD_HA")
+}
+
+func TestRedisFailover_Prepare_UnknownDataProtectionMode(t *testing.T) {
+	a := &redisFailoverAttack{}
+	state := RedisFailoverState{}
+	_, err := a.Prepare(context.Background(), &state, redisReq(validRedisAttrs, map[string]interface{}{"dataProtectionMode": "force_data_loss"}))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Unknown dataProtectionMode")
+}
+
+func TestRedisFailover_Describe(t *testing.T) {
+	a := &redisFailoverAttack{}
+	desc := a.Describe()
+	assert.Equal(t, RedisFailoverActionId, desc.Id)
+	assert.Equal(t, TargetIDRedisInstance, desc.TargetSelection.TargetType)
+	assert.Equal(t, RedisFailoverState{}, a.NewEmptyState())
+}
+
+func TestRedisFailover_NewAction(t *testing.T) {
+	a := NewRedisFailoverAction()
+	assert.NotNil(t, a)
+}
+
+func TestMustHaveAttr(t *testing.T) {
+	attrs := map[string][]string{
+		"present": {"value"},
+		"empty":   {},
+	}
+	assert.Equal(t, "value", mustHaveAttr(attrs, "present"))
+	assert.Equal(t, "", mustHaveAttr(attrs, "missing"))
+	assert.Equal(t, "", mustHaveAttr(attrs, "empty"))
+}

--- a/extmemorystore/redis_discovery_test.go
+++ b/extmemorystore/redis_discovery_test.go
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2026 steadybit GmbH. All rights reserved.
+ */
+
+package extmemorystore
+
+import (
+	"testing"
+
+	"cloud.google.com/go/redis/apiv1/redispb"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestToRedisTarget_Populated(t *testing.T) {
+	inst := &redispb.Instance{
+		Name:                  "projects/proj-a/locations/europe-west1/instances/cache-01",
+		Tier:                  redispb.Instance_STANDARD_HA,
+		RedisVersion:          "REDIS_6_X",
+		LocationId:            "europe-west1-a",
+		AlternativeLocationId: "europe-west1-b",
+		MemorySizeGb:          8,
+		State:                 redispb.Instance_READY,
+		ConnectMode:           redispb.Instance_PRIVATE_SERVICE_ACCESS,
+		AuthEnabled:           true,
+		TransitEncryptionMode: redispb.Instance_SERVER_AUTHENTICATION,
+		ReadReplicasMode:      redispb.Instance_READ_REPLICAS_ENABLED,
+		ReplicaCount:          2,
+		AuthorizedNetwork:     "projects/proj-a/global/networks/default",
+		PersistenceConfig: &redispb.PersistenceConfig{
+			PersistenceMode: redispb.PersistenceConfig_RDB,
+		},
+		Labels: map[string]string{"team": "core"},
+	}
+
+	target := toRedisTarget(inst, "proj-a")
+
+	assert.Equal(t, TargetIDRedisInstance, target.TargetType)
+	assert.Equal(t, "cache-01", target.Label)
+	assert.Equal(t, inst.Name, target.Id)
+	assert.Equal(t, []string{"proj-a"}, target.Attributes[attrProjectID])
+	assert.Equal(t, []string{"cache-01"}, target.Attributes["gcp.memorystore.instance.id"])
+	assert.Equal(t, []string{"europe-west1"}, target.Attributes[attrRegion])
+	assert.Equal(t, []string{"STANDARD_HA"}, target.Attributes[attrTier])
+	assert.Equal(t, []string{"REDIS_6_X"}, target.Attributes[attrRedisVersion])
+	assert.Equal(t, []string{"europe-west1-a"}, target.Attributes["gcp.memorystore.location-id"])
+	assert.Equal(t, []string{"europe-west1-b"}, target.Attributes["gcp.memorystore.alternative-location-id"])
+	assert.Equal(t, []string{"8"}, target.Attributes["gcp.memorystore.memory-size-gb"])
+	assert.Equal(t, []string{"READY"}, target.Attributes["gcp.memorystore.state"])
+	assert.Equal(t, []string{"PRIVATE_SERVICE_ACCESS"}, target.Attributes["gcp.memorystore.connect-mode"])
+	assert.Equal(t, []string{"true"}, target.Attributes["gcp.memorystore.auth-enabled"])
+	assert.Equal(t, []string{"SERVER_AUTHENTICATION"}, target.Attributes["gcp.memorystore.transit-encryption-mode"])
+	assert.Equal(t, []string{"READ_REPLICAS_ENABLED"}, target.Attributes["gcp.memorystore.read-replicas-mode"])
+	assert.Equal(t, []string{"2"}, target.Attributes["gcp.memorystore.replica-count"])
+	assert.Equal(t, []string{"RDB"}, target.Attributes["gcp.memorystore.persistence-mode"])
+	assert.Equal(t, []string{"projects/proj-a/global/networks/default"}, target.Attributes["gcp.memorystore.authorized-network"])
+	assert.Equal(t, []string{"core"}, target.Attributes["gcp.memorystore.label.team"])
+}
+
+func TestToRedisTarget_Sparse(t *testing.T) {
+	inst := &redispb.Instance{
+		Name: "projects/proj-a/locations/europe-west1/instances/sparse",
+	}
+	target := toRedisTarget(inst, "proj-a")
+
+	assert.Equal(t, "sparse", target.Label)
+	assert.NotContains(t, target.Attributes, attrTier)
+	assert.NotContains(t, target.Attributes, attrRedisVersion)
+	assert.NotContains(t, target.Attributes, "gcp.memorystore.memory-size-gb")
+	assert.NotContains(t, target.Attributes, "gcp.memorystore.state")
+	assert.NotContains(t, target.Attributes, "gcp.memorystore.replica-count")
+	assert.NotContains(t, target.Attributes, "gcp.memorystore.persistence-mode")
+	// auth-enabled is written unconditionally
+	assert.Equal(t, []string{"false"}, target.Attributes["gcp.memorystore.auth-enabled"])
+}
+
+func TestToRedisTarget_MalformedName(t *testing.T) {
+	// Name doesn't match the 6-part FQDN — region stays empty, instanceID falls back to raw Name.
+	inst := &redispb.Instance{Name: "truncated"}
+	target := toRedisTarget(inst, "proj-a")
+
+	assert.Equal(t, "truncated", target.Label)
+	assert.Equal(t, []string{"truncated"}, target.Attributes["gcp.memorystore.instance.id"])
+	assert.NotContains(t, target.Attributes, attrRegion)
+}
+
+func TestDescribeMethods(t *testing.T) {
+	d := &redisDiscovery{}
+	assert.Equal(t, TargetIDRedisInstance, d.Describe().Id)
+	assert.Equal(t, TargetIDRedisInstance, d.DescribeTarget().Id)
+	assert.NotEmpty(t, d.DescribeAttributes())
+}
+
+func TestNewRedisDiscovery(t *testing.T) {
+	d := NewRedisDiscovery()
+	assert.NotNil(t, d)
+}
+
+func TestDataProtectionFromString(t *testing.T) {
+	m, ok := dataProtectionFromString("FORCE_DATA_LOSS")
+	assert.True(t, ok)
+	assert.Equal(t, redispb.FailoverInstanceRequest_FORCE_DATA_LOSS, m)
+
+	m, ok = dataProtectionFromString("LIMITED_DATA_LOSS")
+	assert.True(t, ok)
+	assert.Equal(t, redispb.FailoverInstanceRequest_LIMITED_DATA_LOSS, m)
+
+	// Unknown / typo values are rejected — no silent downgrade to LIMITED.
+	m, ok = dataProtectionFromString("force_data_loss")
+	assert.False(t, ok)
+	assert.Equal(t, redispb.FailoverInstanceRequest_DATA_PROTECTION_MODE_UNSPECIFIED, m)
+
+	m, ok = dataProtectionFromString("")
+	assert.False(t, ok)
+	assert.Equal(t, redispb.FailoverInstanceRequest_DATA_PROTECTION_MODE_UNSPECIFIED, m)
+}

--- a/extmig/mig_attack_delete_instances_test.go
+++ b/extmig/mig_attack_delete_instances_test.go
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2026 steadybit GmbH. All rights reserved.
+ */
+
+package extmig
+
+import (
+	"context"
+	"testing"
+
+	"github.com/steadybit/action-kit/go/action_kit_api/v2"
+	"github.com/steadybit/extension-kit/extutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func migPrepareReq(attrs map[string][]string, cfg map[string]interface{}) action_kit_api.PrepareActionRequestBody {
+	return extutil.JsonMangle(action_kit_api.PrepareActionRequestBody{
+		Target: extutil.Ptr(action_kit_api.Target{Attributes: attrs}),
+		Config: cfg,
+	})
+}
+
+var validMigTargetAttrs = map[string][]string{
+	"gcp.project.id":  {"proj-a"},
+	"gcp.mig.scope":   {"zonal"},
+	"gcp.mig.location": {"europe-west1-a"},
+	"gcp.mig.name":    {"web"},
+}
+
+func TestMigDelete_Prepare_MissingRequiredAttr(t *testing.T) {
+	for _, drop := range []string{"gcp.project.id", "gcp.mig.scope", "gcp.mig.location", "gcp.mig.name"} {
+		attrs := map[string][]string{}
+		for k, v := range validMigTargetAttrs {
+			if k != drop {
+				attrs[k] = v
+			}
+		}
+		a := &migDeleteInstancesAttack{}
+		state := MigDeleteInstancesState{}
+		_, err := a.Prepare(context.Background(), &state, migPrepareReq(attrs, map[string]interface{}{"percentage": 33}))
+		require.Error(t, err, "dropping %s should fail Prepare", drop)
+	}
+}
+
+func TestMigDelete_Prepare_PercentageOutOfRange(t *testing.T) {
+	a := &migDeleteInstancesAttack{}
+	state := MigDeleteInstancesState{}
+
+	// 0% invalid
+	_, err := a.Prepare(context.Background(), &state, migPrepareReq(validMigTargetAttrs, map[string]interface{}{"percentage": 0}))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "percentage")
+
+	// 101% invalid
+	_, err = a.Prepare(context.Background(), &state, migPrepareReq(validMigTargetAttrs, map[string]interface{}{"percentage": 101}))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "percentage")
+}
+
+func TestMigDelete_Prepare_HighImpactGate(t *testing.T) {
+	a := &migDeleteInstancesAttack{}
+	state := MigDeleteInstancesState{}
+
+	// >50% without confirmHighImpact rejected
+	_, err := a.Prepare(context.Background(), &state, migPrepareReq(validMigTargetAttrs, map[string]interface{}{"percentage": 51}))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Allow percentages above 50%")
+}
+
+func TestMigDelete_Describe(t *testing.T) {
+	a := &migDeleteInstancesAttack{}
+	desc := a.Describe()
+	assert.Equal(t, MigDeleteInstancesActionId, desc.Id)
+	assert.Equal(t, TargetIDMig, desc.TargetSelection.TargetType)
+	assert.Equal(t, MigDeleteInstancesState{}, a.NewEmptyState())
+}
+
+func TestMigDelete_NewAction(t *testing.T) {
+	a := NewMigDeleteInstancesAction()
+	assert.NotNil(t, a)
+}
+
+func TestMigDelete_Start_NoInstancesSelected(t *testing.T) {
+	a := &migDeleteInstancesAttack{}
+	state := &MigDeleteInstancesState{}
+	_, err := a.Start(context.Background(), state)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "No instances selected")
+}
+
+func TestMigDelete_ListRunningInstances_UnsupportedScope(t *testing.T) {
+	a := &migDeleteInstancesAttack{}
+	_, err := a.listRunningInstances(context.Background(), &MigDeleteInstancesState{
+		ProjectID: "proj-a", Scope: "unknown", Location: "x", MigName: "y",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported")
+}

--- a/extmig/mig_discovery_test.go
+++ b/extmig/mig_discovery_test.go
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2026 steadybit GmbH. All rights reserved.
+ */
+
+package extmig
+
+import (
+	"testing"
+
+	"cloud.google.com/go/compute/apiv1/computepb"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseScope(t *testing.T) {
+	scope, loc := parseScope("zones/us-central1-a")
+	assert.Equal(t, "zonal", scope)
+	assert.Equal(t, "us-central1-a", loc)
+
+	scope, loc = parseScope("regions/europe-west1")
+	assert.Equal(t, "regional", scope)
+	assert.Equal(t, "europe-west1", loc)
+
+	scope, loc = parseScope("something-weird")
+	assert.Equal(t, "unknown", scope)
+	assert.Equal(t, "something-weird", loc)
+}
+
+func TestToMigTarget_Zonal(t *testing.T) {
+	base := "base"
+	tmpl := "projects/proj-a/global/instanceTemplates/tmpl-01"
+	shape := "EVEN"
+	upType := "PROACTIVE"
+	repl := "SUBSTITUTE"
+	minAct := "REPLACE"
+	hc := "projects/proj-a/global/healthChecks/hc"
+	zoneA := "projects/proj-a/zones/europe-west1-a"
+
+	mig := &computepb.InstanceGroupManager{
+		Name:             ptr("web-mig"),
+		SelfLink:         ptr("https://compute.googleapis.com/.../instanceGroupManagers/web-mig"),
+		TargetSize:       ptrI32(4),
+		BaseInstanceName: &base,
+		InstanceTemplate: &tmpl,
+		DistributionPolicy: &computepb.DistributionPolicy{
+			TargetShape: &shape,
+			Zones:       []*computepb.DistributionPolicyZoneConfiguration{{Zone: &zoneA}, {}, {Zone: ptr("")}},
+		},
+		UpdatePolicy: &computepb.InstanceGroupManagerUpdatePolicy{
+			Type:              &upType,
+			ReplacementMethod: &repl,
+			MinimalAction:     &minAct,
+		},
+		AutoHealingPolicies: []*computepb.InstanceGroupManagerAutoHealingPolicy{
+			{HealthCheck: &hc},
+			nil,
+			{},
+		},
+		StatefulPolicy: &computepb.StatefulPolicy{},
+	}
+
+	target := toMigTarget(mig, "zonal", "europe-west1-a", "proj-a")
+
+	assert.Equal(t, TargetIDMig, target.TargetType)
+	assert.Equal(t, "web-mig", target.Label)
+	assert.Equal(t, "https://compute.googleapis.com/.../instanceGroupManagers/web-mig", target.Id)
+	assert.Equal(t, []string{"proj-a"}, target.Attributes[attrProjectID])
+	assert.Equal(t, []string{"web-mig"}, target.Attributes["gcp.mig.name"])
+	assert.Equal(t, []string{"zonal"}, target.Attributes[attrScope])
+	assert.Equal(t, []string{"europe-west1-a"}, target.Attributes[attrLocation])
+	assert.Equal(t, []string{"4"}, target.Attributes[attrTargetSize])
+	assert.Equal(t, []string{"base"}, target.Attributes["gcp.mig.base-instance-name"])
+	assert.Equal(t, []string{tmpl}, target.Attributes["gcp.mig.instance-template"])
+	assert.Equal(t, []string{"EVEN"}, target.Attributes["gcp.mig.distribution-policy.target-shape"])
+	// Nil / empty-name zones are filtered out.
+	assert.Equal(t, []string{zoneA}, target.Attributes["gcp.mig.distribution-policy.zones"])
+	assert.Equal(t, []string{"PROACTIVE"}, target.Attributes["gcp.mig.update-policy.type"])
+	assert.Equal(t, []string{"SUBSTITUTE"}, target.Attributes["gcp.mig.update-policy.replacement-method"])
+	assert.Equal(t, []string{"REPLACE"}, target.Attributes["gcp.mig.update-policy.minimal-action"])
+	assert.Equal(t, []string{hc}, target.Attributes["gcp.mig.auto-healing-policies.health-check"])
+	assert.Equal(t, []string{"true"}, target.Attributes["gcp.mig.stateful-policy.configured"])
+}
+
+func TestToMigTarget_Sparse(t *testing.T) {
+	mig := &computepb.InstanceGroupManager{
+		Name:     ptr("bare"),
+		SelfLink: ptr("selflink"),
+	}
+	target := toMigTarget(mig, "regional", "europe-west1", "proj-a")
+
+	assert.Equal(t, "bare", target.Label)
+	assert.Equal(t, []string{"regional"}, target.Attributes[attrScope])
+	assert.Equal(t, []string{"europe-west1"}, target.Attributes[attrLocation])
+	assert.Equal(t, []string{"0"}, target.Attributes[attrTargetSize])
+	assert.NotContains(t, target.Attributes, "gcp.mig.distribution-policy.target-shape")
+	assert.NotContains(t, target.Attributes, "gcp.mig.update-policy.type")
+	assert.NotContains(t, target.Attributes, "gcp.mig.auto-healing-policies.health-check")
+	// stateful-policy.configured is written unconditionally.
+	assert.Equal(t, []string{"false"}, target.Attributes["gcp.mig.stateful-policy.configured"])
+}
+
+func TestMigDescribeMethods(t *testing.T) {
+	d := &migDiscovery{}
+	assert.Equal(t, TargetIDMig, d.Describe().Id)
+	assert.Equal(t, TargetIDMig, d.DescribeTarget().Id)
+	assert.NotEmpty(t, d.DescribeAttributes())
+}
+
+func TestNewMigDiscovery(t *testing.T) {
+	assert.NotNil(t, NewMigDiscovery())
+}
+
+func ptr(s string) *string { return &s }
+func ptrI32(v int32) *int32 { return &v }

--- a/extnat/nat_attack_disassociate_test.go
+++ b/extnat/nat_attack_disassociate_test.go
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2026 steadybit GmbH. All rights reserved.
+ */
+
+package extnat
+
+import (
+	"context"
+	"testing"
+
+	"cloud.google.com/go/compute/apiv1/computepb"
+	"github.com/steadybit/action-kit/go/action_kit_api/v2"
+	"github.com/steadybit/extension-kit/extutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func natPrepareReq(attrs map[string][]string) action_kit_api.PrepareActionRequestBody {
+	return extutil.JsonMangle(action_kit_api.PrepareActionRequestBody{
+		Target: extutil.Ptr(action_kit_api.Target{Attributes: attrs}),
+	})
+}
+
+var validNatAttrs = map[string][]string{
+	"gcp.project.id":     {"proj-a"},
+	"gcp.cloud-nat.region": {"europe-west1"},
+	"gcp.cloud-nat.router": {"main-router"},
+	"gcp.cloud-nat.name":   {"main-nat"},
+}
+
+func TestNatDisassociate_Prepare_MissingRequiredAttr(t *testing.T) {
+	for _, drop := range []string{"gcp.project.id", "gcp.cloud-nat.region", "gcp.cloud-nat.router", "gcp.cloud-nat.name"} {
+		attrs := map[string][]string{}
+		for k, v := range validNatAttrs {
+			if k != drop {
+				attrs[k] = v
+			}
+		}
+		a := &cloudNatDisassociateAttack{}
+		state := CloudNatDisassociateState{}
+		_, err := a.Prepare(context.Background(), &state, natPrepareReq(attrs))
+		require.Error(t, err, "dropping %s should fail Prepare", drop)
+		assert.Contains(t, err.Error(), "missing")
+	}
+}
+
+func TestNatDisassociate_Describe(t *testing.T) {
+	a := &cloudNatDisassociateAttack{}
+	desc := a.Describe()
+	assert.Equal(t, CloudNatDisassociateActionId, desc.Id)
+	assert.Equal(t, TargetIDCloudNat, desc.TargetSelection.TargetType)
+	assert.NotNil(t, desc.Stop)
+	assert.Equal(t, CloudNatDisassociateState{}, a.NewEmptyState())
+}
+
+func TestNatDisassociate_NewAction(t *testing.T) {
+	a := NewCloudNatDisassociateAction()
+	assert.NotNil(t, a)
+}
+
+func TestToSubnetworkProtos(t *testing.T) {
+	snaps := []natSubnetSnapshot{
+		{Name: "subnet-a", SourceIPRangesToNat: []string{"ALL_IP_RANGES"}},
+		{Name: "subnet-b", SecondaryIPRangeNames: []string{"secondary-1"}},
+	}
+	protos := toSubnetworkProtos(snaps)
+	require.Len(t, protos, 2)
+
+	// Reconstruct back for a round-trip sanity check on the pointer marshalling.
+	assert.Equal(t, "subnet-a", *protos[0].Name)
+	assert.Equal(t, []string{"ALL_IP_RANGES"}, protos[0].SourceIpRangesToNat)
+	assert.Equal(t, "subnet-b", *protos[1].Name)
+	assert.Equal(t, []string{"secondary-1"}, protos[1].SecondaryIpRangeNames)
+}
+
+// Compile-time coverage: this pulls in the RouterNat proto type to make sure
+// natSubnetSnapshot struct changes stay proto-compatible.
+var _ = &computepb.RouterNat{}
+
+func TestSnapshotNatSubnetworks_Found(t *testing.T) {
+	router := &computepb.Router{
+		Nats: []*computepb.RouterNat{
+			{Name: ptr("other-nat"), Subnetworks: []*computepb.RouterNatSubnetworkToNat{{Name: ptr("other-subnet")}}},
+			{
+				Name: ptr("target-nat"),
+				Subnetworks: []*computepb.RouterNatSubnetworkToNat{
+					{Name: ptr("subnet-a"), SourceIpRangesToNat: []string{"ALL_IP_RANGES"}},
+					nil,
+					{Name: ptr("subnet-b"), SecondaryIpRangeNames: []string{"secondary-1"}},
+				},
+			},
+		},
+	}
+	found, snaps := snapshotNatSubnetworks(router, "target-nat")
+	assert.True(t, found)
+	require.Len(t, snaps, 2)
+	assert.Equal(t, "subnet-a", snaps[0].Name)
+	assert.Equal(t, []string{"ALL_IP_RANGES"}, snaps[0].SourceIPRangesToNat)
+	assert.Equal(t, "subnet-b", snaps[1].Name)
+	assert.Equal(t, []string{"secondary-1"}, snaps[1].SecondaryIPRangeNames)
+}
+
+func TestSnapshotNatSubnetworks_NotFound(t *testing.T) {
+	router := &computepb.Router{
+		Nats: []*computepb.RouterNat{{Name: ptr("other-nat")}},
+	}
+	found, snaps := snapshotNatSubnetworks(router, "missing")
+	assert.False(t, found)
+	assert.Nil(t, snaps)
+}
+
+func TestSnapshotNatSubnetworks_FoundButEmpty(t *testing.T) {
+	router := &computepb.Router{
+		Nats: []*computepb.RouterNat{{Name: ptr("solo")}},
+	}
+	found, snaps := snapshotNatSubnetworks(router, "solo")
+	assert.True(t, found)
+	assert.Empty(t, snaps)
+}
+
+func TestPopulatePrepareTarget(t *testing.T) {
+	// Success
+	state := &CloudNatDisassociateState{}
+	err := populatePrepareTarget(state, natPrepareReq(validNatAttrs))
+	require.NoError(t, err)
+	assert.Equal(t, "proj-a", state.ProjectID)
+	assert.Equal(t, "main-nat", state.NatName)
+
+	// Missing attribute fails.
+	err = populatePrepareTarget(&CloudNatDisassociateState{}, natPrepareReq(map[string][]string{"gcp.project.id": {"p"}}))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "missing")
+}

--- a/extnat/nat_discovery_test.go
+++ b/extnat/nat_discovery_test.go
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2026 steadybit GmbH. All rights reserved.
+ */
+
+package extnat
+
+import (
+	"testing"
+
+	"cloud.google.com/go/compute/apiv1/computepb"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestToNatTarget_Populated(t *testing.T) {
+	true_ := true
+	router := &computepb.Router{
+		Name:     ptr("main-router"),
+		SelfLink: ptr("projects/proj-a/regions/europe-west1/routers/main-router"),
+		Network:  ptr("projects/proj-a/global/networks/default"),
+	}
+	nat := &computepb.RouterNat{
+		Name:                         ptr("main-nat"),
+		SourceSubnetworkIpRangesToNat: ptr("LIST_OF_SUBNETWORKS"),
+		NatIpAllocateOption:          ptr("MANUAL_ONLY"),
+		NatIps:                       []string{"projects/proj-a/regions/europe-west1/addresses/nat-b", "projects/proj-a/regions/europe-west1/addresses/nat-a"},
+		EndpointTypes:                []string{"ENDPOINT_TYPE_SWG", "ENDPOINT_TYPE_VM"},
+		Subnetworks: []*computepb.RouterNatSubnetworkToNat{
+			{Name: ptr("subnet-b")},
+			nil,
+			{Name: ptr("subnet-a")},
+			{Name: ptr("")},
+		},
+		MinPortsPerVm: ptrI32(64),
+		LogConfig: &computepb.RouterNatLogConfig{
+			Enable: &true_,
+		},
+		EnableDynamicPortAllocation: &true_,
+	}
+
+	target := toNatTarget(router, nat, "europe-west1", "proj-a")
+
+	assert.Equal(t, TargetIDCloudNat, target.TargetType)
+	assert.Equal(t, "main-router/main-nat", target.Label)
+	assert.Equal(t, "projects/proj-a/regions/europe-west1/routers/main-router/nats/main-nat", target.Id)
+	assert.Equal(t, []string{"proj-a"}, target.Attributes[attrProjectID])
+	assert.Equal(t, []string{"main-nat"}, target.Attributes["gcp.cloud-nat.name"])
+	assert.Equal(t, []string{"main-router"}, target.Attributes["gcp.cloud-nat.router"])
+	assert.Equal(t, []string{"europe-west1"}, target.Attributes[attrRegion])
+	assert.Equal(t, []string{"projects/proj-a/global/networks/default"}, target.Attributes["gcp.cloud-nat.network"])
+	assert.Equal(t, []string{"LIST_OF_SUBNETWORKS"}, target.Attributes[attrSourceSubnetworkIpRanges])
+	assert.Equal(t, []string{"MANUAL_ONLY"}, target.Attributes["gcp.cloud-nat.nat-ip-allocate-option"])
+	// NatIps and EndpointTypes should be sorted.
+	assert.Equal(t, []string{"projects/proj-a/regions/europe-west1/addresses/nat-a", "projects/proj-a/regions/europe-west1/addresses/nat-b"}, target.Attributes["gcp.cloud-nat.nat-ips"])
+	assert.Equal(t, []string{"ENDPOINT_TYPE_SWG", "ENDPOINT_TYPE_VM"}, target.Attributes["gcp.cloud-nat.endpoint-types"])
+	// Subnetworks filtered (nil + empty-name skipped) and sorted.
+	assert.Equal(t, []string{"subnet-a", "subnet-b"}, target.Attributes["gcp.cloud-nat.subnetworks"])
+	// subnetwork-count matches the filtered list, not the raw slice length.
+	assert.Equal(t, []string{"2"}, target.Attributes[attrSubnetworkCount])
+	assert.Equal(t, []string{"64"}, target.Attributes["gcp.cloud-nat.min-ports-per-vm"])
+	assert.Equal(t, []string{"true"}, target.Attributes["gcp.cloud-nat.log-config.enable"])
+	assert.Equal(t, []string{"true"}, target.Attributes["gcp.cloud-nat.enable-dynamic-port-allocation"])
+}
+
+func TestToNatTarget_Sparse(t *testing.T) {
+	router := &computepb.Router{Name: ptr("r"), SelfLink: ptr("s")}
+	nat := &computepb.RouterNat{Name: ptr("n")}
+
+	target := toNatTarget(router, nat, "europe-west1", "proj-a")
+
+	assert.Equal(t, "r/n", target.Label)
+	assert.Equal(t, []string{"0"}, target.Attributes[attrSubnetworkCount])
+	assert.NotContains(t, target.Attributes, "gcp.cloud-nat.network")
+	assert.NotContains(t, target.Attributes, attrSourceSubnetworkIpRanges)
+	assert.NotContains(t, target.Attributes, "gcp.cloud-nat.nat-ips")
+	assert.NotContains(t, target.Attributes, "gcp.cloud-nat.subnetworks")
+	assert.NotContains(t, target.Attributes, "gcp.cloud-nat.min-ports-per-vm")
+	assert.NotContains(t, target.Attributes, "gcp.cloud-nat.log-config.enable")
+	assert.NotContains(t, target.Attributes, "gcp.cloud-nat.enable-dynamic-port-allocation")
+}
+
+func TestNatDescribeMethods(t *testing.T) {
+	d := &natDiscovery{}
+	assert.Equal(t, TargetIDCloudNat, d.Describe().Id)
+	assert.Equal(t, TargetIDCloudNat, d.DescribeTarget().Id)
+	assert.NotEmpty(t, d.DescribeAttributes())
+}
+
+func TestNewNatDiscovery(t *testing.T) {
+	assert.NotNil(t, NewNatDiscovery())
+}
+
+func ptr(s string) *string  { return &s }
+func ptrI32(v int32) *int32 { return &v }

--- a/extpubsub/pubsub_discovery_test.go
+++ b/extpubsub/pubsub_discovery_test.go
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2026 steadybit GmbH. All rights reserved.
+ */
+
+package extpubsub
+
+import (
+	"testing"
+	"time"
+
+	"cloud.google.com/go/pubsub/v2/apiv1/pubsubpb"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/types/known/durationpb"
+)
+
+func TestToTopicTarget_Populated(t *testing.T) {
+	topic := &pubsubpb.Topic{
+		Name:                     "projects/proj-a/topics/orders",
+		MessageRetentionDuration: durationpb.New(24 * time.Hour),
+		KmsKeyName:               "projects/proj-a/locations/global/keyRings/kr/cryptoKeys/k",
+		MessageStoragePolicy: &pubsubpb.MessageStoragePolicy{
+			AllowedPersistenceRegions: []string{"europe-west1", "us-central1"},
+			EnforceInTransit:          true,
+		},
+		SchemaSettings: &pubsubpb.SchemaSettings{
+			Schema:   "projects/proj-a/schemas/order",
+			Encoding: pubsubpb.Encoding_JSON,
+		},
+		State:        pubsubpb.Topic_ACTIVE,
+		SatisfiesPzs: true,
+		Labels:       map[string]string{"team": "core"},
+	}
+
+	target := toTopicTarget(topic, "proj-a")
+
+	assert.Equal(t, TargetIDTopic, target.TargetType)
+	assert.Equal(t, "orders", target.Label)
+	assert.Equal(t, topic.Name, target.Id)
+	assert.Equal(t, []string{"proj-a"}, target.Attributes[attrProjectID])
+	assert.Equal(t, []string{"orders"}, target.Attributes["gcp.pubsub.topic.name"])
+	assert.Equal(t, []string{"24h0m0s"}, target.Attributes[attrTopicMessageRetentionDuration])
+	assert.Equal(t, []string{"projects/proj-a/locations/global/keyRings/kr/cryptoKeys/k"}, target.Attributes[attrTopicKmsKeyName])
+	assert.Equal(t, []string{"europe-west1", "us-central1"}, target.Attributes["gcp.pubsub.topic.message-storage-policy.allowed-persistence-regions"])
+	assert.Equal(t, []string{"true"}, target.Attributes["gcp.pubsub.topic.message-storage-policy.enforce-in-transit"])
+	assert.Equal(t, []string{"projects/proj-a/schemas/order"}, target.Attributes["gcp.pubsub.topic.schema-settings.schema"])
+	assert.Equal(t, []string{"JSON"}, target.Attributes["gcp.pubsub.topic.schema-settings.encoding"])
+	assert.Equal(t, []string{"ACTIVE"}, target.Attributes["gcp.pubsub.topic.state"])
+	assert.Equal(t, []string{"true"}, target.Attributes["gcp.pubsub.topic.satisfies-pzs"])
+	assert.Equal(t, []string{"core"}, target.Attributes["gcp.pubsub.topic.label.team"])
+}
+
+func TestToTopicTarget_Sparse(t *testing.T) {
+	topic := &pubsubpb.Topic{Name: "projects/proj-a/topics/sparse"}
+	target := toTopicTarget(topic, "proj-a")
+	assert.Equal(t, "sparse", target.Label)
+	assert.NotContains(t, target.Attributes, attrTopicMessageRetentionDuration)
+	assert.NotContains(t, target.Attributes, attrTopicKmsKeyName)
+	// satisfies-pzs always emitted
+	assert.Equal(t, []string{"false"}, target.Attributes["gcp.pubsub.topic.satisfies-pzs"])
+}
+
+func TestToSubscriptionTarget_Push(t *testing.T) {
+	sub := &pubsubpb.Subscription{
+		Name:                      "projects/proj-a/subscriptions/orders-sub",
+		Topic:                     "projects/proj-a/topics/orders",
+		AckDeadlineSeconds:        20,
+		MessageRetentionDuration:  durationpb.New(7 * 24 * time.Hour),
+		RetainAckedMessages:       false,
+		EnableMessageOrdering:     true,
+		EnableExactlyOnceDelivery: true,
+		Detached:                  false,
+		Filter:                    "attributes.type = \"paid\"",
+		State:                     pubsubpb.Subscription_ACTIVE,
+		PushConfig:                &pubsubpb.PushConfig{PushEndpoint: "https://example.com/webhook"},
+		DeadLetterPolicy: &pubsubpb.DeadLetterPolicy{
+			DeadLetterTopic:     "projects/proj-a/topics/dead",
+			MaxDeliveryAttempts: 5,
+		},
+		RetryPolicy: &pubsubpb.RetryPolicy{
+			MinimumBackoff: durationpb.New(1 * time.Second),
+			MaximumBackoff: durationpb.New(60 * time.Second),
+		},
+		ExpirationPolicy: &pubsubpb.ExpirationPolicy{Ttl: durationpb.New(31 * 24 * time.Hour)},
+		Labels:           map[string]string{"team": "core"},
+	}
+
+	target := toSubscriptionTarget(sub, "proj-a")
+
+	assert.Equal(t, TargetIDSubscription, target.TargetType)
+	assert.Equal(t, "orders-sub", target.Label)
+	assert.Equal(t, sub.Name, target.Id)
+	assert.Equal(t, []string{"proj-a"}, target.Attributes[attrProjectID])
+	assert.Equal(t, []string{"orders-sub"}, target.Attributes["gcp.pubsub.subscription.name"])
+	assert.Equal(t, []string{"projects/proj-a/topics/orders"}, target.Attributes[attrSubscriptionTopic])
+	assert.Equal(t, []string{"push"}, target.Attributes[attrSubscriptionDeliveryType])
+	assert.Equal(t, []string{"20"}, target.Attributes[attrSubscriptionAckDeadlineSeconds])
+	assert.Equal(t, []string{"true"}, target.Attributes["gcp.pubsub.subscription.enable-message-ordering"])
+	assert.Equal(t, []string{"true"}, target.Attributes["gcp.pubsub.subscription.enable-exactly-once-delivery"])
+	assert.Equal(t, []string{"attributes.type = \"paid\""}, target.Attributes["gcp.pubsub.subscription.filter"])
+	assert.Equal(t, []string{"ACTIVE"}, target.Attributes["gcp.pubsub.subscription.state"])
+	assert.Equal(t, []string{"https://example.com/webhook"}, target.Attributes["gcp.pubsub.subscription.push-config.endpoint"])
+	assert.Equal(t, []string{"projects/proj-a/topics/dead"}, target.Attributes["gcp.pubsub.subscription.dead-letter-policy.topic"])
+	assert.Equal(t, []string{"5"}, target.Attributes["gcp.pubsub.subscription.dead-letter-policy.max-delivery-attempts"])
+	assert.Equal(t, []string{"1s"}, target.Attributes["gcp.pubsub.subscription.retry-policy.minimum-backoff"])
+	assert.Equal(t, []string{"1m0s"}, target.Attributes["gcp.pubsub.subscription.retry-policy.maximum-backoff"])
+	assert.Equal(t, []string{"core"}, target.Attributes["gcp.pubsub.subscription.label.team"])
+}
+
+func TestToSubscriptionTarget_DeliveryTypeMatrix(t *testing.T) {
+	base := &pubsubpb.Subscription{Name: "projects/p/subscriptions/s"}
+
+	// Pull (default)
+	assert.Equal(t, "pull", deliveryType(base))
+
+	// Push
+	base.PushConfig = &pubsubpb.PushConfig{PushEndpoint: "https://x"}
+	assert.Equal(t, "push", deliveryType(base))
+	base.PushConfig = nil
+
+	// BigQuery
+	base.BigqueryConfig = &pubsubpb.BigQueryConfig{Table: "t"}
+	assert.Equal(t, "bigquery", deliveryType(base))
+	base.BigqueryConfig = nil
+
+	// Cloud Storage
+	base.CloudStorageConfig = &pubsubpb.CloudStorageConfig{Bucket: "b"}
+	assert.Equal(t, "cloud-storage", deliveryType(base))
+	base.CloudStorageConfig = nil
+
+	// Bigtable
+	base.BigtableConfig = &pubsubpb.BigtableConfig{Table: "t"}
+	assert.Equal(t, "bigtable", deliveryType(base))
+}
+
+func TestToSubscriptionTarget_Sparse(t *testing.T) {
+	sub := &pubsubpb.Subscription{Name: "projects/proj-a/subscriptions/sparse"}
+	target := toSubscriptionTarget(sub, "proj-a")
+	assert.Equal(t, "sparse", target.Label)
+	assert.Equal(t, []string{"pull"}, target.Attributes[attrSubscriptionDeliveryType])
+	// Always-emit booleans still show up:
+	assert.Equal(t, []string{"false"}, target.Attributes["gcp.pubsub.subscription.retain-acked-messages"])
+	assert.Equal(t, []string{"false"}, target.Attributes["gcp.pubsub.subscription.enable-message-ordering"])
+	assert.NotContains(t, target.Attributes, attrSubscriptionAckDeadlineSeconds)
+}
+
+func TestPubsubDescribeMethods(t *testing.T) {
+	td := &topicDiscovery{}
+	assert.Equal(t, TargetIDTopic, td.Describe().Id)
+	assert.Equal(t, TargetIDTopic, td.DescribeTarget().Id)
+	assert.NotEmpty(t, td.DescribeAttributes())
+
+	sd := &subscriptionDiscovery{}
+	assert.Equal(t, TargetIDSubscription, sd.Describe().Id)
+	assert.Equal(t, TargetIDSubscription, sd.DescribeTarget().Id)
+	assert.NotEmpty(t, sd.DescribeAttributes())
+}
+
+func TestNewPubsubDiscoveries(t *testing.T) {
+	assert.NotNil(t, NewTopicDiscovery())
+	assert.NotNil(t, NewSubscriptionDiscovery())
+}

--- a/extspanner/instance_discovery_test.go
+++ b/extspanner/instance_discovery_test.go
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2026 steadybit GmbH. All rights reserved.
+ */
+
+package extspanner
+
+import (
+	"testing"
+
+	"cloud.google.com/go/spanner/admin/instance/apiv1/instancepb"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestToInstanceTarget_Populated(t *testing.T) {
+	inst := &instancepb.Instance{
+		Name:                      "projects/proj-a/instances/prod",
+		DisplayName:               "Production",
+		Config:                    "projects/proj-a/instanceConfigs/regional-europe-west1",
+		Edition:                   instancepb.Instance_ENTERPRISE,
+		InstanceType:              instancepb.Instance_PROVISIONED,
+		State:                     instancepb.Instance_READY,
+		NodeCount:                 3,
+		ProcessingUnits:           3000,
+		AutoscalingConfig:         &instancepb.AutoscalingConfig{},
+		DefaultBackupScheduleType: instancepb.Instance_AUTOMATIC,
+		Labels:                    map[string]string{"team": "core"},
+	}
+
+	target := toInstanceTarget(inst, "proj-a")
+
+	assert.Equal(t, TargetIDInstance, target.TargetType)
+	assert.Equal(t, "prod", target.Label)
+	assert.Equal(t, "projects/proj-a/instances/prod", target.Id)
+	assert.Equal(t, []string{"proj-a"}, target.Attributes[attrProjectID])
+	assert.Equal(t, []string{"prod"}, target.Attributes["gcp.spanner.instance.name"])
+	assert.Equal(t, []string{"Production"}, target.Attributes["gcp.spanner.instance.display-name"])
+	assert.Equal(t, []string{"regional-europe-west1"}, target.Attributes[attrConfig])
+	assert.Equal(t, []string{"ENTERPRISE"}, target.Attributes[attrEdition])
+	assert.Equal(t, []string{"PROVISIONED"}, target.Attributes["gcp.spanner.instance.type"])
+	assert.Equal(t, []string{"READY"}, target.Attributes["gcp.spanner.instance.state"])
+	assert.Equal(t, []string{"3"}, target.Attributes["gcp.spanner.instance.node-count"])
+	assert.Equal(t, []string{"3000"}, target.Attributes[attrProcessingUnits])
+	assert.Equal(t, []string{"true"}, target.Attributes["gcp.spanner.instance.autoscaling.configured"])
+	assert.Equal(t, []string{"AUTOMATIC"}, target.Attributes["gcp.spanner.instance.default-backup-schedule-type"])
+	assert.Equal(t, []string{"core"}, target.Attributes["gcp.spanner.instance.label.team"])
+}
+
+func TestToInstanceTarget_Sparse(t *testing.T) {
+	inst := &instancepb.Instance{
+		Name: "projects/proj-a/instances/sparse",
+	}
+	target := toInstanceTarget(inst, "proj-a")
+
+	assert.Equal(t, "sparse", target.Label)
+	assert.NotContains(t, target.Attributes, "gcp.spanner.instance.display-name")
+	assert.NotContains(t, target.Attributes, attrConfig)
+	assert.NotContains(t, target.Attributes, attrEdition)
+	assert.NotContains(t, target.Attributes, "gcp.spanner.instance.state")
+	assert.NotContains(t, target.Attributes, "gcp.spanner.instance.node-count")
+	assert.NotContains(t, target.Attributes, attrProcessingUnits)
+	// autoscaling.configured is written unconditionally; when AutoscalingConfig is nil, it's "false".
+	assert.Equal(t, []string{"false"}, target.Attributes["gcp.spanner.instance.autoscaling.configured"])
+}
+
+func TestDescribeMethods(t *testing.T) {
+	d := &instanceDiscovery{}
+	assert.Equal(t, TargetIDInstance, d.Describe().Id)
+	assert.Equal(t, TargetIDInstance, d.DescribeTarget().Id)
+	assert.NotEmpty(t, d.DescribeAttributes())
+}
+
+func TestNewInstanceDiscovery(t *testing.T) {
+	d := NewInstanceDiscovery()
+	assert.NotNil(t, d)
+}


### PR DESCRIPTION
## Summary

Sonar's quality gate on \`main\` was failing at **25.2%** coverage — the 10 new packages added in #334 (11 target types, 5 attacks) had **zero** test coverage between them. This bulk-adds a \`*_test.go\` file per package.

**Local \`go tool cover -func\` total: 58.6% (up from 10.4%).** Per-package on the new files:
- extcloudrun **72%**, extcloudsql **70%**, extpubsub **70%**, extdisk **68%**, extspanner **67%**, extgke **65%**, extmemorystore **65%**, extnat **53%**, extmig **40%**.

## Approach

- **Pure \`toXTarget(...)\` transforms** — populated + sparse proto cases, asserting each attribute key/value including the SetStr / SetBool / SetInt64IfPositive guard semantics.
- **Every attack Prepare's validation branches** — missing target attributes, out-of-range percentage, \`confirmHighImpact\` gate, \`dataProtectionMode\` enum, \`tier != STANDARD_HA\` rejection, unsupported MIG scope.
- **Pure helper functions** — \`parseScope\`, \`parseZonalMIGUrl\`, \`dataProtectionFromString\` (both the enum match and the \`false, UNSPECIFIED\` fallback), \`snapshotNatSubnetworks\`, \`populatePrepareTarget\`, \`toSubnetworkProtos\`.
- **Smoke tests** for \`Describe\` / \`DescribeTarget\` / \`DescribeAttributes\` / \`NewXDiscovery\` in every package.

## Deferred to a follow-up

\`extmig.Start\` / \`listRunningInstances\` and \`extnat.Start\` / \`Stop\` / \`setNatSubnetworks\` still call the real GCP APIs behind unmocked client providers. Covering those requires a fake iterator implementation (~50 more lines of test scaffolding per package). Leaving that until we see what shape Sonar's quality gate actually needs — if 58% doesn't clear the threshold, next PR wires the fakes.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [x] All 100+ new tests pass locally
- [ ] Sonar re-scan on merge → quality gate should flip green