### PR TITLE
fix(attacks): tighten descriptions and align Technology='GCP'

### DIFF
--- a/extcloudsql/instance_attack_failover.go
+++ b/extcloudsql/instance_attack_failover.go
@@ -51,9 +51,7 @@ func (a *cloudSqlFailoverAttack) Describe() action_kit_api.ActionDescription {
 	return action_kit_api.ActionDescription{
 		Id:    InstanceFailoverActionId,
 		Label: "Trigger Cloud SQL failover",
-		Description: "Triggers a failover from the primary instance to its REGIONAL standby. Only works on Cloud SQL instances with availability-type=REGIONAL (HA). " +
-			"Validates that your application correctly handles the brief connection interruption and follows the secondary's new primary role. " +
-			"This is not reversible — it exercises the same code path as a real zonal outage; Cloud SQL rebuilds a new HA standby after the failover.",
+		Description: "Fails over a REGIONAL Cloud SQL HA instance to its standby. Not reversible.",
 		Version: extbuild.GetSemverVersionStringOrUnknown(),
 		Icon:    extutil.Ptr(targetIcon),
 		TargetSelection: extutil.Ptr(action_kit_api.TargetSelection{
@@ -66,7 +64,7 @@ func (a *cloudSqlFailoverAttack) Describe() action_kit_api.ActionDescription {
 				},
 			}),
 		}),
-		Technology:  extutil.Ptr("Google Cloud"),
+		Technology:  extutil.Ptr("GCP"),
 		Category:    extutil.Ptr("Cloud SQL"),
 		TimeControl: action_kit_api.TimeControlInstantaneous,
 		Kind:        action_kit_api.Attack,

--- a/extgke/nodepool_attack_terminate_instances.go
+++ b/extgke/nodepool_attack_terminate_instances.go
@@ -78,11 +78,7 @@ func (a *nodePoolTerminateInstancesAttack) Describe() action_kit_api.ActionDescr
 	return action_kit_api.ActionDescription{
 		Id:    NodePoolTerminateInstancesActionId,
 		Label: "Terminate GKE node pool instances",
-		Description: "Destructively deletes a percentage of instances from a GKE node pool via the underlying Managed Instance Group(s). " +
-			"The MIG creates new replacements driven by its scaling/heal policies — typical recovery is minutes, but a node pool with " +
-			"cluster-autoscaler disabled or surge=0 can stay undersized indefinitely. Validates pod rescheduling, PDB enforcement, " +
-			"cluster-autoscaler scale-up, and stateful workload zonal failover. " +
-			"This attack is not reversible: the deleted instances are gone. Percentages above 50% require explicit confirmation.",
+		Description: "Deletes a percentage of instances from a GKE node pool via the underlying MIG. Not reversible — MIG scaling recreates replacements.",
 		Version: extbuild.GetSemverVersionStringOrUnknown(),
 		Icon:    extutil.Ptr(targetIcon),
 		TargetSelection: extutil.Ptr(action_kit_api.TargetSelection{
@@ -95,7 +91,7 @@ func (a *nodePoolTerminateInstancesAttack) Describe() action_kit_api.ActionDescr
 				},
 			}),
 		}),
-		Technology:  extutil.Ptr("Google Cloud"),
+		Technology:  extutil.Ptr("GCP"),
 		Category:    extutil.Ptr("GKE"),
 		TimeControl: action_kit_api.TimeControlInstantaneous,
 		Kind:        action_kit_api.Attack,

--- a/extmemorystore/redis_attack_failover.go
+++ b/extmemorystore/redis_attack_failover.go
@@ -56,10 +56,7 @@ func (a *redisFailoverAttack) Describe() action_kit_api.ActionDescription {
 	return action_kit_api.ActionDescription{
 		Id:    RedisFailoverActionId,
 		Label: "Trigger Memorystore for Redis failover",
-		Description: "Triggers a failover from the primary node to a replica for a STANDARD_HA tier Memorystore for Redis instance. " +
-			"Validates that connection-pool retry / reconnect logic survives the brief read/write interruption. " +
-			"This is not reversible — it exercises the same code path as a real primary-node outage. " +
-			"FORCE_DATA_LOSS may drop in-flight writes that have not yet been replicated.",
+		Description: "Fails over a STANDARD_HA Memorystore Redis instance's primary to its replica. Not reversible.",
 		Version: extbuild.GetSemverVersionStringOrUnknown(),
 		Icon:    extutil.Ptr(targetIcon),
 		TargetSelection: extutil.Ptr(action_kit_api.TargetSelection{
@@ -72,7 +69,7 @@ func (a *redisFailoverAttack) Describe() action_kit_api.ActionDescription {
 				},
 			}),
 		}),
-		Technology:  extutil.Ptr("Google Cloud"),
+		Technology:  extutil.Ptr("GCP"),
 		Category:    extutil.Ptr("Memorystore"),
 		TimeControl: action_kit_api.TimeControlInstantaneous,
 		Kind:        action_kit_api.Attack,

--- a/extmig/mig_attack_delete_instances.go
+++ b/extmig/mig_attack_delete_instances.go
@@ -94,10 +94,7 @@ func (a *migDeleteInstancesAttack) Describe() action_kit_api.ActionDescription {
 	return action_kit_api.ActionDescription{
 		Id:    MigDeleteInstancesActionId,
 		Label: "Delete MIG instances",
-		Description: "Destructively deletes a percentage of RUNNING instances from a Managed Instance Group. The MIG creates new replacements per " +
-			"its scaling/heal policies — typical recovery is minutes, but a MIG without autoscaling can stay undersized indefinitely. " +
-			"Validates that workloads on the MIG tolerate the loss of N% of nodes. " +
-			"This attack is not reversible: the deleted instances are gone. Percentages above 50% require explicit confirmation.",
+		Description: "Deletes a percentage of RUNNING instances from a Managed Instance Group. Not reversible — MIG scaling recreates replacements.",
 		Version: extbuild.GetSemverVersionStringOrUnknown(),
 		Icon:    extutil.Ptr(targetIcon),
 		TargetSelection: extutil.Ptr(action_kit_api.TargetSelection{
@@ -110,7 +107,7 @@ func (a *migDeleteInstancesAttack) Describe() action_kit_api.ActionDescription {
 				},
 			}),
 		}),
-		Technology:  extutil.Ptr("Google Cloud"),
+		Technology:  extutil.Ptr("GCP"),
 		Category:    extutil.Ptr("Compute Engine"),
 		TimeControl: action_kit_api.TimeControlInstantaneous,
 		Kind:        action_kit_api.Attack,

--- a/extnat/nat_attack_disassociate.go
+++ b/extnat/nat_attack_disassociate.go
@@ -68,8 +68,7 @@ func (a *cloudNatDisassociateAttack) Describe() action_kit_api.ActionDescription
 	return action_kit_api.ActionDescription{
 		Id:    CloudNatDisassociateActionId,
 		Label: "Disassociate Cloud NAT from its subnetworks",
-		Description: "Removes all subnetworks from the Cloud NAT's configuration so VMs in those subnets lose their NAT egress to the internet. " +
-			"Subnetworks are restored on stop. Other NATs sharing the same router are preserved untouched.",
+		Description: "Removes all subnetworks from a Cloud NAT so VMs in those subnets lose internet egress. Restored on stop.",
 		Version: extbuild.GetSemverVersionStringOrUnknown(),
 		Icon:    extutil.Ptr(targetIcon),
 		TargetSelection: extutil.Ptr(action_kit_api.TargetSelection{
@@ -82,7 +81,7 @@ func (a *cloudNatDisassociateAttack) Describe() action_kit_api.ActionDescription
 				},
 			}),
 		}),
-		Technology:  extutil.Ptr("Google Cloud"),
+		Technology:  extutil.Ptr("GCP"),
 		Category:    extutil.Ptr("Cloud NAT"),
 		TimeControl: action_kit_api.TimeControlExternal,
 		Kind:        action_kit_api.Attack,


### PR DESCRIPTION
## Summary

Two UX polish fixes on the five attacks landed by PR #334, surfaced after they showed up in the platform UI:

- **Descriptions were 3-4 sentences each** — collapsed to one sentence each. The multi-sentence rationale / reversibility narrative belongs in the README, not the action-picker card.
- **\`Technology: "Google Cloud"\` → \`"GCP"\`** on all five attacks — matches the pre-existing \`extvm\` state action (\`extvm/vm_attack_state.go:72\`), so all Steadybit-native GCP actions group under a single \`GCP\` header instead of two separate \`Google Cloud\` / \`GCP\` folders.

## Before / after

| Attack | Before (excerpt) | After |
|---|---|---|
| Cloud NAT disassociate | "Removes all subnetworks from the Cloud NAT's configuration so VMs in those subnets lose their NAT egress to the internet. Subnetworks are restored on stop. Other NATs sharing the same router are preserved untouched." | "Removes all subnetworks from a Cloud NAT so VMs in those subnets lose internet egress. Restored on stop." |
| Cloud SQL failover | 3-sentence rationale | "Fails over a REGIONAL Cloud SQL HA instance to its standby. Not reversible." |
| MIG delete-instances | 4-sentence rationale | "Deletes a percentage of RUNNING instances from a Managed Instance Group. Not reversible — MIG scaling recreates replacements." |
| GKE terminate-instances | 5-sentence rationale | "Deletes a percentage of instances from a GKE node pool via the underlying MIG. Not reversible — MIG scaling recreates replacements." |
| Memorystore Redis failover | 4-sentence rationale incl. FORCE_DATA_LOSS caveat | "Fails over a STANDARD_HA Memorystore Redis instance's primary to its replica. Not reversible." |

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [x] All existing tests pass
- [ ] After merge + Helm subchart bump on the demo cluster, verify attacks now render under a single \`GCP\` header in the action picker with one-line descriptions