### PR TITLE
fix: shorten Pub/Sub topic persistence regions attribute name

### DIFF
--- a/extpubsub/pubsub_discovery_test.go
+++ b/extpubsub/pubsub_discovery_test.go
@@ -40,7 +40,7 @@ func TestToTopicTarget_Populated(t *testing.T) {
 	assert.Equal(t, []string{"orders"}, target.Attributes["gcp.pubsub.topic.name"])
 	assert.Equal(t, []string{"24h0m0s"}, target.Attributes[attrTopicMessageRetentionDuration])
 	assert.Equal(t, []string{"projects/proj-a/locations/global/keyRings/kr/cryptoKeys/k"}, target.Attributes[attrTopicKmsKeyName])
-	assert.Equal(t, []string{"europe-west1", "us-central1"}, target.Attributes["gcp.pubsub.topic.message-storage-policy.allowed-persistence-regions"])
+	assert.Equal(t, []string{"europe-west1", "us-central1"}, target.Attributes["gcp.pubsub.topic.message-storage-policy.persistence-regions"])
 	assert.Equal(t, []string{"true"}, target.Attributes["gcp.pubsub.topic.message-storage-policy.enforce-in-transit"])
 	assert.Equal(t, []string{"projects/proj-a/schemas/order"}, target.Attributes["gcp.pubsub.topic.schema-settings.schema"])
 	assert.Equal(t, []string{"JSON"}, target.Attributes["gcp.pubsub.topic.schema-settings.encoding"])

--- a/extpubsub/topic_discovery.go
+++ b/extpubsub/topic_discovery.go
@@ -69,7 +69,7 @@ func (d *topicDiscovery) DescribeAttributes() []discovery_kit_api.AttributeDescr
 		{Attribute: "gcp.pubsub.topic.name", Label: discovery_kit_api.PluralLabel{One: "Pub/Sub topic name", Other: "Pub/Sub topic names"}},
 		{Attribute: attrTopicMessageRetentionDuration, Label: discovery_kit_api.PluralLabel{One: "Pub/Sub topic message retention", Other: "Pub/Sub topic message retentions"}},
 		{Attribute: attrTopicKmsKeyName, Label: discovery_kit_api.PluralLabel{One: "Pub/Sub topic KMS key", Other: "Pub/Sub topic KMS keys"}},
-		{Attribute: "gcp.pubsub.topic.message-storage-policy.allowed-persistence-regions", Label: discovery_kit_api.PluralLabel{One: "Pub/Sub topic allowed region", Other: "Pub/Sub topic allowed regions"}},
+		{Attribute: "gcp.pubsub.topic.message-storage-policy.persistence-regions", Label: discovery_kit_api.PluralLabel{One: "Pub/Sub topic allowed region", Other: "Pub/Sub topic allowed regions"}},
 		{Attribute: "gcp.pubsub.topic.message-storage-policy.enforce-in-transit", Label: discovery_kit_api.PluralLabel{One: "Pub/Sub topic enforce in-transit", Other: "Pub/Sub topic enforce in-transit"}},
 		{Attribute: "gcp.pubsub.topic.schema-settings.schema", Label: discovery_kit_api.PluralLabel{One: "Pub/Sub topic schema", Other: "Pub/Sub topic schemas"}},
 		{Attribute: "gcp.pubsub.topic.schema-settings.encoding", Label: discovery_kit_api.PluralLabel{One: "Pub/Sub topic schema encoding", Other: "Pub/Sub topic schema encodings"}},
@@ -126,7 +126,7 @@ func toTopicTarget(t *pubsubpb.Topic, projectID string) discovery_kit_api.Target
 	if t.MessageStoragePolicy != nil {
 		if len(t.MessageStoragePolicy.AllowedPersistenceRegions) > 0 {
 			regions := append([]string(nil), t.MessageStoragePolicy.AllowedPersistenceRegions...)
-			attributes["gcp.pubsub.topic.message-storage-policy.allowed-persistence-regions"] = regions
+			attributes["gcp.pubsub.topic.message-storage-policy.persistence-regions"] = regions
 		}
 		attributes["gcp.pubsub.topic.message-storage-policy.enforce-in-transit"] = []string{strconv.FormatBool(t.MessageStoragePolicy.EnforceInTransit)}
 	}


### PR DESCRIPTION
## Problem

The agent rejects the extension's attribute description response:

```
HTTP response from extension at GET http://steadybit-agent-extension-gcp.steadybit-agent.svc.cluster.local:8093/discovery/attributes is invalid. Details:
	$.attributes[124].attribute: size must be between 0 and 64
```

The offender is `gcp.pubsub.topic.message-storage-policy.allowed-persistence-regions` (67 characters), defined in `extpubsub/topic_discovery.go`. Because the merged attribute list is served as one document, a single oversized name invalidates the entire `/discovery/attributes` response.

## Fix

Renamed to `gcp.pubsub.topic.message-storage-policy.persistence-regions` (59 characters), in both the attribute description and the discovery code that sets it.

## Notes

- A scan of all Go sources shows this was the only attribute name above 64 characters. The next longest, `gcp.pubsub.subscription.dead-letter-policy.max-delivery-attempts`, is exactly 64 — legal, but with no headroom.
- The attribute does not exist at `v1.0.30`; it came in with the unreleased 11-GCP-services feature (63b430b). So this only affects `main`/dev builds and needs no migration or CHANGELOG entry.
- `go build ./...` and `go test ./extpubsub/...` pass.