### PR TITLE
cleanup: dedupe shared attribute descriptors

### DIFF
--- a/extcloudrun/service_discovery.go
+++ b/extcloudrun/service_discovery.go
@@ -80,7 +80,6 @@ func (d *serviceDiscovery) DescribeAttributes() []discovery_kit_api.AttributeDes
 		{Attribute: "gcp.cloudrun.service.template.scaling.min-instance-count", Label: discovery_kit_api.PluralLabel{One: "Cloud Run revision min instances", Other: "Cloud Run revision min instances"}},
 		{Attribute: "gcp.cloudrun.service.template.scaling.max-instance-count", Label: discovery_kit_api.PluralLabel{One: "Cloud Run revision max instances", Other: "Cloud Run revision max instances"}},
 		{Attribute: "gcp.cloudrun.service.urls", Label: discovery_kit_api.PluralLabel{One: "Cloud Run service URL", Other: "Cloud Run service URLs"}},
-		{Attribute: attrProjectID, Label: discovery_kit_api.PluralLabel{One: "GCP project ID", Other: "GCP project IDs"}},
 	}
 }
 

--- a/extcloudsql/instance_discovery.go
+++ b/extcloudsql/instance_discovery.go
@@ -83,7 +83,6 @@ func (d *instanceDiscovery) DescribeAttributes() []discovery_kit_api.AttributeDe
 		{Attribute: "gcp.cloudsql.disk-type", Label: discovery_kit_api.PluralLabel{One: "Cloud SQL disk type", Other: "Cloud SQL disk types"}},
 		{Attribute: "gcp.cloudsql.disk-size-gb", Label: discovery_kit_api.PluralLabel{One: "Cloud SQL disk size (GiB)", Other: "Cloud SQL disk sizes (GiB)"}},
 		{Attribute: "gcp.cloudsql.maintenance-window.day", Label: discovery_kit_api.PluralLabel{One: "Cloud SQL maintenance day", Other: "Cloud SQL maintenance days"}},
-		{Attribute: "gcp.project.id", Label: discovery_kit_api.PluralLabel{One: "GCP project ID", Other: "GCP project IDs"}},
 	}
 }
 

--- a/extdisk/disk_discovery.go
+++ b/extdisk/disk_discovery.go
@@ -93,7 +93,6 @@ func (d *diskDiscovery) DescribeAttributes() []discovery_kit_api.AttributeDescri
 		{Attribute: "gcp.persistent-disk.provisioned-iops", Label: discovery_kit_api.PluralLabel{One: "Disk provisioned IOPS", Other: "Disk provisioned IOPS"}},
 		{Attribute: "gcp.persistent-disk.provisioned-throughput", Label: discovery_kit_api.PluralLabel{One: "Disk provisioned throughput", Other: "Disk provisioned throughputs"}},
 		{Attribute: "gcp.persistent-disk.architecture", Label: discovery_kit_api.PluralLabel{One: "Disk architecture", Other: "Disk architectures"}},
-		{Attribute: attrProjectID, Label: discovery_kit_api.PluralLabel{One: "GCP project ID", Other: "GCP project IDs"}},
 	}
 }
 

--- a/extgke/cluster_discovery.go
+++ b/extgke/cluster_discovery.go
@@ -121,7 +121,6 @@ func (d *clusterDiscovery) DescribeAttributes() []discovery_kit_api.AttributeDes
 		{Attribute: attrClusterLoggingService, Label: discovery_kit_api.PluralLabel{One: "GKE logging service", Other: "GKE logging services"}},
 		{Attribute: attrClusterMonitoringService, Label: discovery_kit_api.PluralLabel{One: "GKE monitoring service", Other: "GKE monitoring services"}},
 		{Attribute: "gcp.gke.cluster.node-locations", Label: discovery_kit_api.PluralLabel{One: "GKE node location", Other: "GKE node locations"}},
-		{Attribute: attrProjectID, Label: discovery_kit_api.PluralLabel{One: "GCP project ID", Other: "GCP project IDs"}},
 		{Attribute: attrK8sClusterName, Label: discovery_kit_api.PluralLabel{One: "Kubernetes cluster name", Other: "Kubernetes cluster names"}},
 	}
 }

--- a/extgke/nodepool_discovery.go
+++ b/extgke/nodepool_discovery.go
@@ -67,8 +67,6 @@ func (d *nodePoolDiscovery) DescribeTarget() discovery_kit_api.TargetDescription
 
 func (d *nodePoolDiscovery) DescribeAttributes() []discovery_kit_api.AttributeDescription {
 	return []discovery_kit_api.AttributeDescription{
-		{Attribute: attrClusterName, Label: discovery_kit_api.PluralLabel{One: "GKE cluster name", Other: "GKE cluster names"}},
-		{Attribute: "gcp.gke.cluster.location", Label: discovery_kit_api.PluralLabel{One: "GKE cluster location", Other: "GKE cluster locations"}},
 		{Attribute: "gcp.gke.nodepool.name", Label: discovery_kit_api.PluralLabel{One: "GKE node pool name", Other: "GKE node pool names"}},
 		{Attribute: attrNodePoolKubernetesVersion, Label: discovery_kit_api.PluralLabel{One: "GKE node pool Kubernetes version", Other: "GKE node pool Kubernetes versions"}},
 		{Attribute: "gcp.gke.nodepool.status", Label: discovery_kit_api.PluralLabel{One: "GKE node pool status", Other: "GKE node pool statuses"}},
@@ -88,8 +86,6 @@ func (d *nodePoolDiscovery) DescribeAttributes() []discovery_kit_api.AttributeDe
 		{Attribute: "gcp.gke.nodepool.upgrade-settings.max-surge", Label: discovery_kit_api.PluralLabel{One: "GKE node pool max surge", Other: "GKE node pool max surges"}},
 		{Attribute: "gcp.gke.nodepool.upgrade-settings.max-unavailable", Label: discovery_kit_api.PluralLabel{One: "GKE node pool max unavailable", Other: "GKE node pool max unavailable"}},
 		{Attribute: "gcp.gke.nodepool.instance-group-urls", Label: discovery_kit_api.PluralLabel{One: "GKE node pool MIG URL", Other: "GKE node pool MIG URLs"}},
-		{Attribute: "gcp.project.id", Label: discovery_kit_api.PluralLabel{One: "GCP project ID", Other: "GCP project IDs"}},
-		{Attribute: "k8s.cluster-name", Label: discovery_kit_api.PluralLabel{One: "Kubernetes cluster name", Other: "Kubernetes cluster names"}},
 	}
 }
 

--- a/extmemorystore/redis_discovery.go
+++ b/extmemorystore/redis_discovery.go
@@ -82,7 +82,6 @@ func (d *redisDiscovery) DescribeAttributes() []discovery_kit_api.AttributeDescr
 		{Attribute: "gcp.memorystore.replica-count", Label: discovery_kit_api.PluralLabel{One: "Memorystore replica count", Other: "Memorystore replica counts"}},
 		{Attribute: "gcp.memorystore.persistence-mode", Label: discovery_kit_api.PluralLabel{One: "Memorystore persistence mode", Other: "Memorystore persistence modes"}},
 		{Attribute: "gcp.memorystore.authorized-network", Label: discovery_kit_api.PluralLabel{One: "Memorystore authorized network", Other: "Memorystore authorized networks"}},
-		{Attribute: attrProjectID, Label: discovery_kit_api.PluralLabel{One: "GCP project ID", Other: "GCP project IDs"}},
 	}
 }
 

--- a/extmig/mig_discovery.go
+++ b/extmig/mig_discovery.go
@@ -80,7 +80,6 @@ func (d *migDiscovery) DescribeAttributes() []discovery_kit_api.AttributeDescrip
 		{Attribute: "gcp.mig.update-policy.replacement-method", Label: discovery_kit_api.PluralLabel{One: "MIG update replacement method", Other: "MIG update replacement methods"}},
 		{Attribute: "gcp.mig.update-policy.minimal-action", Label: discovery_kit_api.PluralLabel{One: "MIG update minimal action", Other: "MIG update minimal actions"}},
 		{Attribute: "gcp.mig.stateful-policy.configured", Label: discovery_kit_api.PluralLabel{One: "MIG stateful policy configured", Other: "MIG stateful policy configured"}},
-		{Attribute: attrProjectID, Label: discovery_kit_api.PluralLabel{One: "GCP project ID", Other: "GCP project IDs"}},
 	}
 }
 

--- a/extnat/nat_discovery.go
+++ b/extnat/nat_discovery.go
@@ -81,7 +81,6 @@ func (d *natDiscovery) DescribeAttributes() []discovery_kit_api.AttributeDescrip
 		{Attribute: "gcp.cloud-nat.min-ports-per-vm", Label: discovery_kit_api.PluralLabel{One: "Cloud NAT min ports per VM", Other: "Cloud NAT min ports per VM"}},
 		{Attribute: "gcp.cloud-nat.log-config.enable", Label: discovery_kit_api.PluralLabel{One: "Cloud NAT logging", Other: "Cloud NAT logging"}},
 		{Attribute: "gcp.cloud-nat.enable-dynamic-port-allocation", Label: discovery_kit_api.PluralLabel{One: "Cloud NAT dynamic port allocation", Other: "Cloud NAT dynamic port allocation"}},
-		{Attribute: attrProjectID, Label: discovery_kit_api.PluralLabel{One: "GCP project ID", Other: "GCP project IDs"}},
 	}
 }
 

--- a/extpubsub/subscription_discovery.go
+++ b/extpubsub/subscription_discovery.go
@@ -84,7 +84,6 @@ func (d *subscriptionDiscovery) DescribeAttributes() []discovery_kit_api.Attribu
 		{Attribute: "gcp.pubsub.subscription.retry-policy.minimum-backoff", Label: discovery_kit_api.PluralLabel{One: "Pub/Sub subscription retry min backoff", Other: "Pub/Sub subscription retry min backoffs"}},
 		{Attribute: "gcp.pubsub.subscription.retry-policy.maximum-backoff", Label: discovery_kit_api.PluralLabel{One: "Pub/Sub subscription retry max backoff", Other: "Pub/Sub subscription retry max backoffs"}},
 		{Attribute: "gcp.pubsub.subscription.expiration-policy.ttl", Label: discovery_kit_api.PluralLabel{One: "Pub/Sub subscription expiration TTL", Other: "Pub/Sub subscription expiration TTLs"}},
-		{Attribute: attrProjectID, Label: discovery_kit_api.PluralLabel{One: "GCP project ID", Other: "GCP project IDs"}},
 	}
 }
 

--- a/extpubsub/topic_discovery.go
+++ b/extpubsub/topic_discovery.go
@@ -75,7 +75,6 @@ func (d *topicDiscovery) DescribeAttributes() []discovery_kit_api.AttributeDescr
 		{Attribute: "gcp.pubsub.topic.schema-settings.encoding", Label: discovery_kit_api.PluralLabel{One: "Pub/Sub topic schema encoding", Other: "Pub/Sub topic schema encodings"}},
 		{Attribute: "gcp.pubsub.topic.state", Label: discovery_kit_api.PluralLabel{One: "Pub/Sub topic state", Other: "Pub/Sub topic states"}},
 		{Attribute: "gcp.pubsub.topic.satisfies-pzs", Label: discovery_kit_api.PluralLabel{One: "Pub/Sub topic PZS compliance", Other: "Pub/Sub topic PZS compliance"}},
-		{Attribute: attrProjectID, Label: discovery_kit_api.PluralLabel{One: "GCP project ID", Other: "GCP project IDs"}},
 	}
 }
 

--- a/extspanner/instance_discovery.go
+++ b/extspanner/instance_discovery.go
@@ -77,7 +77,6 @@ func (d *instanceDiscovery) DescribeAttributes() []discovery_kit_api.AttributeDe
 		{Attribute: attrProcessingUnits, Label: discovery_kit_api.PluralLabel{One: "Spanner instance processing units", Other: "Spanner instance processing units"}},
 		{Attribute: "gcp.spanner.instance.autoscaling.configured", Label: discovery_kit_api.PluralLabel{One: "Spanner instance autoscaling configured", Other: "Spanner instance autoscaling configured"}},
 		{Attribute: "gcp.spanner.instance.default-backup-schedule-type", Label: discovery_kit_api.PluralLabel{One: "Spanner default backup schedule", Other: "Spanner default backup schedules"}},
-		{Attribute: attrProjectID, Label: discovery_kit_api.PluralLabel{One: "GCP project ID", Other: "GCP project IDs"}},
 	}
 }
 

--- a/extvm/vm_discovery.go
+++ b/extvm/vm_discovery.go
@@ -180,8 +180,8 @@ func (d *vmDiscovery) DescribeAttributes() []discovery_kit_api.AttributeDescript
 		{
 			Attribute: attrProjectID,
 			Label: discovery_kit_api.PluralLabel{
-				One:   "Project ID",
-				Other: "Project IDs",
+				One:   "GCP project ID",
+				Other: "GCP project IDs",
 			},
 		},
 		{


### PR DESCRIPTION
## Summary

Cosmetic fix for the \`attribute X is defined multiple times\` warnings that showed up on every \`extension-gcp\` startup after #334 landed:

\`\`\`
attribute gcp.project.id is defined multiple times
attribute gcp.gke.cluster.name is defined multiple times
attribute gcp.gke.cluster.location is defined multiple times
attribute k8s.cluster-name is defined multiple times
\`\`\`

Cause: every new package's \`DescribeAttributes()\` re-declared \`gcp.project.id\`, and \`extgke\`'s cluster + nodepool discoveries both declared the three cluster-scoped attributes.

## Fix — one canonical declaration per shared attribute

| Attribute | Canonical owner |
|---|---|
| \`gcp.project.id\` | \`extvm/vm_discovery.go\` (always-on discovery) |
| \`gcp.gke.cluster.name\` | \`extgke/cluster_discovery.go\` |
| \`gcp.gke.cluster.location\` | \`extgke/cluster_discovery.go\` |
| \`k8s.cluster-name\` | \`extgke/cluster_discovery.go\` |

Nodepool discovery continues to *use* those attributes in its target's \`Attributes\` map (and in the enrichment join keyed on them via the cluster's descriptor). Only the redundant descriptor lines are removed.

Also aligned \`extvm\`'s \`gcp.project.id\` label from \`"Project ID"/"Project IDs"\` → \`"GCP project ID"/"GCP project IDs"\` — the new packages were already using the more descriptive form; \`extvm\` was the odd one out.

## Test plan

- [x] \`go build ./...\`, \`go vet ./...\`, \`go test ./...\` (non-e2e) all clean
- [x] \`helm lint\` / \`helm unittest\` clean
- [ ] After merge + chart bump on demo cluster, confirm the 4 \`defined multiple times\` warnings no longer appear at startup