### PR TITLE
fix(cloud-nat, mig, gke): three attack-implementation fixes

### DIFF
--- a/extgke/nodepool_attack_terminate_instances.go
+++ b/extgke/nodepool_attack_terminate_instances.go
@@ -26,8 +26,10 @@ import (
 	"google.golang.org/api/iterator"
 )
 
-// NodePoolTerminateInstancesState captures enough state to execute the terminate-instances attack.
-// This attack is destructive and is NOT reversible: deleted instances are gone; the MIG behind the node
+// NodePoolTerminateInstancesState captures enough state to execute the recreate-instances attack.
+// This attack calls the MIG's RecreateInstances API — VMs are deleted and replaced from the current
+// instance template without changing the node pool's targetSize. Pods on the recreated nodes are
+// evicted and rescheduled. Not reversible: the original VMs (and their runtime state) are gone; the MIG behind the node
 // pool creates new replacements driven by its scaling/heal policies (mirrors the EKS / AKS pattern).
 // Replacement time depends on cluster-autoscaler and surge configuration; on a misconfigured pool the
 // pool can remain undersized indefinitely.
@@ -98,8 +100,8 @@ func (a *nodePoolTerminateInstancesAttack) Describe() action_kit_api.ActionDescr
 		Parameters: []action_kit_api.ActionParameter{
 			{
 				Name:         "percentage",
-				Label:        "Percentage of instances to terminate",
-				Description:  extutil.Ptr("Percentage (1-100) of node pool's instances to terminate. Defaults to 33%."),
+				Label:        "Percentage of instances to recreate",
+				Description:  extutil.Ptr("Percentage (1-100) of node pool's instances to recreate. Defaults to 33%."),
 				Type:         action_kit_api.ActionParameterTypeInteger,
 				DefaultValue: extutil.Ptr("33"),
 				Order:        extutil.Ptr(1),
@@ -110,7 +112,7 @@ func (a *nodePoolTerminateInstancesAttack) Describe() action_kit_api.ActionDescr
 			{
 				Name:         "confirmHighImpact",
 				Label:        "Allow percentages above 50%",
-				Description:  extutil.Ptr("Required to enable percentages above 50%. Acknowledges that more than half the node pool will be deleted simultaneously."),
+				Description:  extutil.Ptr("Required to enable percentages above 50%. Acknowledges that more than half the node pool will be recreated simultaneously."),
 				Type:         action_kit_api.ActionParameterTypeBoolean,
 				DefaultValue: extutil.Ptr("false"),
 				Order:        extutil.Ptr(2),
@@ -134,7 +136,7 @@ func (a *nodePoolTerminateInstancesAttack) Prepare(ctx context.Context, state *N
 	}
 	confirmHigh := extutil.ToBool(request.Config["confirmHighImpact"])
 	if pct > 50 && !confirmHigh {
-		return nil, extension_kit.ToError("Percentages above 50% require the 'Allow percentages above 50%' flag — half the node pool will be deleted at once.", nil)
+		return nil, extension_kit.ToError("Percentages above 50% require the 'Allow percentages above 50%' flag — half the node pool will be recreated at once.", nil)
 	}
 	state.Percentage = pct
 
@@ -200,7 +202,7 @@ func (a *nodePoolTerminateInstancesAttack) Prepare(ctx context.Context, state *N
 		}
 	}
 	if len(allInstances) == 0 {
-		return nil, extension_kit.ToError(fmt.Sprintf("GKE node pool %s/%s has no RUNNING instances to terminate", state.ClusterName, state.NodePoolName), nil)
+		return nil, extension_kit.ToError(fmt.Sprintf("GKE node pool %s/%s has no RUNNING instances to recreate", state.ClusterName, state.NodePoolName), nil)
 	}
 
 	// Sort for determinism, then random-sample N%.
@@ -233,7 +235,7 @@ func (a *nodePoolTerminateInstancesAttack) Prepare(ctx context.Context, state *N
 	return &action_kit_api.PrepareResult{
 		Messages: extutil.Ptr([]action_kit_api.Message{{
 			Level:   extutil.Ptr(action_kit_api.Info),
-			Message: fmt.Sprintf("Selected %d of %d RUNNING instance(s) (%d%%) in GKE node pool %s/%s for deletion across %d MIG(s)", sampleSize, len(allInstances), pct, state.ClusterName, state.NodePoolName, len(state.InstancesByMig)),
+			Message: fmt.Sprintf("Selected %d of %d RUNNING instance(s) (%d%%) in GKE node pool %s/%s for recreation across %d MIG(s)", sampleSize, len(allInstances), pct, state.ClusterName, state.NodePoolName, len(state.InstancesByMig)),
 		}}),
 	}, nil
 }

--- a/extgke/nodepool_attack_terminate_instances.go
+++ b/extgke/nodepool_attack_terminate_instances.go
@@ -43,7 +43,7 @@ type NodePoolTerminateInstancesState struct {
 
 type migInstancesApi interface {
 	ListManagedInstances(ctx context.Context, req *computepb.ListManagedInstancesInstanceGroupManagersRequest, opts ...gax.CallOption) *compute.ManagedInstanceIterator
-	DeleteInstances(ctx context.Context, req *computepb.DeleteInstancesInstanceGroupManagerRequest, opts ...gax.CallOption) (*compute.Operation, error)
+	RecreateInstances(ctx context.Context, req *computepb.RecreateInstancesInstanceGroupManagerRequest, opts ...gax.CallOption) (*compute.Operation, error)
 }
 
 type nodePoolTerminateInstancesAttack struct {
@@ -77,8 +77,8 @@ func (a *nodePoolTerminateInstancesAttack) NewEmptyState() NodePoolTerminateInst
 func (a *nodePoolTerminateInstancesAttack) Describe() action_kit_api.ActionDescription {
 	return action_kit_api.ActionDescription{
 		Id:    NodePoolTerminateInstancesActionId,
-		Label: "Terminate GKE node pool instances",
-		Description: "Deletes a percentage of instances from a GKE node pool via the underlying MIG. Not reversible — MIG scaling recreates replacements.",
+		Label: "Recreate GKE node pool instances",
+		Description: "Recreates a percentage of node instances in a GKE node pool via the underlying MIG's RecreateInstances API. The node pool's size is preserved (unlike deleteInstances, which shrinks the MIG). Pods reschedule onto surviving or freshly-recreated nodes. Not reversible.",
 		Version: extbuild.GetSemverVersionStringOrUnknown(),
 		Icon:    extutil.Ptr(targetIcon),
 		TargetSelection: extutil.Ptr(action_kit_api.TargetSelection{
@@ -240,7 +240,7 @@ func (a *nodePoolTerminateInstancesAttack) Prepare(ctx context.Context, state *N
 
 func (a *nodePoolTerminateInstancesAttack) Start(ctx context.Context, state *NodePoolTerminateInstancesState) (*action_kit_api.StartResult, error) {
 	if len(state.InstancesByMig) == 0 {
-		return nil, extension_kit.ToError("No instances selected for termination.", nil)
+		return nil, extension_kit.ToError("No instances selected for recreation.", nil)
 	}
 	client, closer, err := a.migClientProvider(ctx, state.ProjectID)
 	if err != nil {
@@ -250,23 +250,23 @@ func (a *nodePoolTerminateInstancesAttack) Start(ctx context.Context, state *Nod
 	total := 0
 	for key, urls := range state.InstancesByMig {
 		zone, name, _ := strings.Cut(key, "/")
-		_, err := client.DeleteInstances(ctx, &computepb.DeleteInstancesInstanceGroupManagerRequest{
+		_, err := client.RecreateInstances(ctx, &computepb.RecreateInstancesInstanceGroupManagerRequest{
 			Project:              state.ProjectID,
 			Zone:                 zone,
 			InstanceGroupManager: name,
-			InstanceGroupManagersDeleteInstancesRequestResource: &computepb.InstanceGroupManagersDeleteInstancesRequest{
+			InstanceGroupManagersRecreateInstancesRequestResource: &computepb.InstanceGroupManagersRecreateInstancesRequest{
 				Instances: urls,
 			},
 		})
 		if err != nil {
-			return nil, extension_kit.ToError(fmt.Sprintf("Failed to delete instances from MIG %s/%s", zone, name), err)
+			return nil, extension_kit.ToError(fmt.Sprintf("Failed to recreate instances in MIG %s/%s", zone, name), err)
 		}
 		total += len(urls)
 	}
 	return &action_kit_api.StartResult{
 		Messages: extutil.Ptr([]action_kit_api.Message{{
 			Level:   extutil.Ptr(action_kit_api.Info),
-			Message: fmt.Sprintf("Deletion requested for %d instance(s) in GKE node pool %s/%s. GKE will replace them via the underlying MIG.", total, state.ClusterName, state.NodePoolName),
+			Message: fmt.Sprintf("Recreation requested for %d instance(s) in GKE node pool %s/%s. The node pool's size is preserved.", total, state.ClusterName, state.NodePoolName),
 		}}),
 	}, nil
 }

--- a/extmig/mig_attack_delete_instances.go
+++ b/extmig/mig_attack_delete_instances.go
@@ -23,11 +23,12 @@ import (
 	"google.golang.org/api/iterator"
 )
 
-// MigDeleteInstancesState holds the sampled instance URLs to delete on Start.
-// This attack is destructive and is NOT reversible: deleted instances are gone; the MIG creates new
-// replacements per its scaling/heal policies. Recovery time depends on the MIG's autoscaler / surge
-// configuration; a MIG with autoscaling disabled and targetSize manually managed will stay undersized
-// until an operator intervenes.
+// MigDeleteInstancesState holds the sampled instance URLs to recreate on Start.
+// This attack calls the MIG's RecreateInstances API — the target VMs are deleted and replaced from the
+// current instance template. Unlike DeleteInstances, RecreateInstances preserves the MIG's targetSize,
+// so an autoscaler-free MIG (like a fixed-size stateful pool) doesn't stay undersized after the attack.
+// The VMs get new hardware identity (new instance IDs, boot times) but keep their names and any
+// stateful-policy state.
 type MigDeleteInstancesState struct {
 	ProjectID  string
 	Scope      string // "zonal" or "regional"
@@ -45,12 +46,12 @@ type migDeleteInstancesAttack struct {
 
 type zonalMigApi interface {
 	ListManagedInstances(ctx context.Context, req *computepb.ListManagedInstancesInstanceGroupManagersRequest, opts ...gaxOpt) *compute.ManagedInstanceIterator
-	DeleteInstances(ctx context.Context, req *computepb.DeleteInstancesInstanceGroupManagerRequest, opts ...gaxOpt) (*compute.Operation, error)
+	RecreateInstances(ctx context.Context, req *computepb.RecreateInstancesInstanceGroupManagerRequest, opts ...gaxOpt) (*compute.Operation, error)
 }
 
 type regionalMigApi interface {
 	ListManagedInstances(ctx context.Context, req *computepb.ListManagedInstancesRegionInstanceGroupManagersRequest, opts ...gaxOpt) *compute.ManagedInstanceIterator
-	DeleteInstances(ctx context.Context, req *computepb.DeleteInstancesRegionInstanceGroupManagerRequest, opts ...gaxOpt) (*compute.Operation, error)
+	RecreateInstances(ctx context.Context, req *computepb.RecreateInstancesRegionInstanceGroupManagerRequest, opts ...gaxOpt) (*compute.Operation, error)
 }
 
 // gaxOpt is a local alias for gax.CallOption keeping the interfaces above terse.
@@ -93,8 +94,8 @@ func (a *migDeleteInstancesAttack) NewEmptyState() MigDeleteInstancesState {
 func (a *migDeleteInstancesAttack) Describe() action_kit_api.ActionDescription {
 	return action_kit_api.ActionDescription{
 		Id:    MigDeleteInstancesActionId,
-		Label: "Delete MIG instances",
-		Description: "Deletes a percentage of RUNNING instances from a Managed Instance Group. Not reversible — MIG scaling recreates replacements.",
+		Label: "Recreate MIG instances",
+		Description: "Recreates a percentage of RUNNING instances in a Managed Instance Group. The MIG's targetSize is preserved (unlike deleteInstances, which shrinks it). Not reversible.",
 		Version: extbuild.GetSemverVersionStringOrUnknown(),
 		Icon:    extutil.Ptr(targetIcon),
 		TargetSelection: extutil.Ptr(action_kit_api.TargetSelection{
@@ -114,8 +115,8 @@ func (a *migDeleteInstancesAttack) Describe() action_kit_api.ActionDescription {
 		Parameters: []action_kit_api.ActionParameter{
 			{
 				Name:         "percentage",
-				Label:        "Percentage of instances to delete",
-				Description:  extutil.Ptr("Percentage (1-100) of MIG's RUNNING instances to delete. Defaults to 33%."),
+				Label:        "Percentage of instances to recreate",
+				Description:  extutil.Ptr("Percentage (1-100) of MIG's RUNNING instances to recreate. Defaults to 33%."),
 				Type:         action_kit_api.ActionParameterTypeInteger,
 				DefaultValue: extutil.Ptr("33"),
 				Order:        extutil.Ptr(1),
@@ -126,7 +127,7 @@ func (a *migDeleteInstancesAttack) Describe() action_kit_api.ActionDescription {
 			{
 				Name:         "confirmHighImpact",
 				Label:        "Allow percentages above 50%",
-				Description:  extutil.Ptr("Required to enable percentages above 50%. Acknowledges that more than half the MIG will be deleted simultaneously."),
+				Description:  extutil.Ptr("Required to enable percentages above 50%. Acknowledges that more than half the MIG will be recreated simultaneously."),
 				Type:         action_kit_api.ActionParameterTypeBoolean,
 				DefaultValue: extutil.Ptr("false"),
 				Order:        extutil.Ptr(2),
@@ -150,7 +151,7 @@ func (a *migDeleteInstancesAttack) Prepare(ctx context.Context, state *MigDelete
 	}
 	confirmHigh := extutil.ToBool(request.Config["confirmHighImpact"])
 	if pct > 50 && !confirmHigh {
-		return nil, extension_kit.ToError("Percentages above 50% require the 'Allow percentages above 50%' flag — half the MIG will be deleted at once.", nil)
+		return nil, extension_kit.ToError("Percentages above 50% require the 'Allow percentages above 50%' flag — half the MIG will be recreated at once.", nil)
 	}
 	state.Percentage = pct
 
@@ -159,7 +160,7 @@ func (a *migDeleteInstancesAttack) Prepare(ctx context.Context, state *MigDelete
 		return nil, extension_kit.ToError(fmt.Sprintf("Failed to list MIG instances for %s/%s", state.Location, state.MigName), err)
 	}
 	if len(allInstances) == 0 {
-		return nil, extension_kit.ToError(fmt.Sprintf("MIG %s/%s has no RUNNING instances to delete", state.Location, state.MigName), nil)
+		return nil, extension_kit.ToError(fmt.Sprintf("MIG %s/%s has no RUNNING instances to recreate", state.Location, state.MigName), nil)
 	}
 	sort.Strings(allInstances)
 	// Use math.Floor (not math.Ceil) so the sample never exceeds the requested
@@ -191,7 +192,7 @@ func (a *migDeleteInstancesAttack) Prepare(ctx context.Context, state *MigDelete
 	return &action_kit_api.PrepareResult{
 		Messages: extutil.Ptr([]action_kit_api.Message{{
 			Level:   extutil.Ptr(action_kit_api.Info),
-			Message: fmt.Sprintf("Selected %d of %d RUNNING instance(s) (%d%%) in MIG %s/%s for deletion", sampleSize, len(allInstances), pct, state.Location, state.MigName),
+			Message: fmt.Sprintf("Selected %d of %d RUNNING instance(s) (%d%%) in MIG %s/%s for recreation", sampleSize, len(allInstances), pct, state.Location, state.MigName),
 		}}),
 	}, nil
 }
@@ -253,7 +254,7 @@ func (a *migDeleteInstancesAttack) listRunningInstances(ctx context.Context, sta
 
 func (a *migDeleteInstancesAttack) Start(ctx context.Context, state *MigDeleteInstancesState) (*action_kit_api.StartResult, error) {
 	if len(state.Instances) == 0 {
-		return nil, extension_kit.ToError("No instances selected for deletion.", nil)
+		return nil, extension_kit.ToError("No instances selected for recreation.", nil)
 	}
 	switch state.Scope {
 	case "zonal":
@@ -262,16 +263,16 @@ func (a *migDeleteInstancesAttack) Start(ctx context.Context, state *MigDeleteIn
 			return nil, extension_kit.ToError(fmt.Sprintf("Failed to create MIG client for project %s", state.ProjectID), err)
 		}
 		defer closer()
-		_, err = client.DeleteInstances(ctx, &computepb.DeleteInstancesInstanceGroupManagerRequest{
+		_, err = client.RecreateInstances(ctx, &computepb.RecreateInstancesInstanceGroupManagerRequest{
 			Project:              state.ProjectID,
 			Zone:                 state.Location,
 			InstanceGroupManager: state.MigName,
-			InstanceGroupManagersDeleteInstancesRequestResource: &computepb.InstanceGroupManagersDeleteInstancesRequest{
+			InstanceGroupManagersRecreateInstancesRequestResource: &computepb.InstanceGroupManagersRecreateInstancesRequest{
 				Instances: state.Instances,
 			},
 		})
 		if err != nil {
-			return nil, extension_kit.ToError(fmt.Sprintf("Failed to delete instances from MIG %s/%s", state.Location, state.MigName), err)
+			return nil, extension_kit.ToError(fmt.Sprintf("Failed to recreate instances in MIG %s/%s", state.Location, state.MigName), err)
 		}
 	case "regional":
 		client, closer, err := a.regionalClientProvider(ctx, state.ProjectID)
@@ -279,16 +280,16 @@ func (a *migDeleteInstancesAttack) Start(ctx context.Context, state *MigDeleteIn
 			return nil, extension_kit.ToError(fmt.Sprintf("Failed to create regional MIG client for project %s", state.ProjectID), err)
 		}
 		defer closer()
-		_, err = client.DeleteInstances(ctx, &computepb.DeleteInstancesRegionInstanceGroupManagerRequest{
+		_, err = client.RecreateInstances(ctx, &computepb.RecreateInstancesRegionInstanceGroupManagerRequest{
 			Project:              state.ProjectID,
 			Region:               state.Location,
 			InstanceGroupManager: state.MigName,
-			RegionInstanceGroupManagersDeleteInstancesRequestResource: &computepb.RegionInstanceGroupManagersDeleteInstancesRequest{
+			RegionInstanceGroupManagersRecreateRequestResource: &computepb.RegionInstanceGroupManagersRecreateRequest{
 				Instances: state.Instances,
 			},
 		})
 		if err != nil {
-			return nil, extension_kit.ToError(fmt.Sprintf("Failed to delete instances from regional MIG %s/%s", state.Location, state.MigName), err)
+			return nil, extension_kit.ToError(fmt.Sprintf("Failed to recreate instances in regional MIG %s/%s", state.Location, state.MigName), err)
 		}
 	default:
 		return nil, extension_kit.ToError(fmt.Sprintf("unsupported MIG scope %q", state.Scope), nil)
@@ -296,7 +297,7 @@ func (a *migDeleteInstancesAttack) Start(ctx context.Context, state *MigDeleteIn
 	return &action_kit_api.StartResult{
 		Messages: extutil.Ptr([]action_kit_api.Message{{
 			Level:   extutil.Ptr(action_kit_api.Info),
-			Message: fmt.Sprintf("Deletion requested for %d instance(s) in MIG %s/%s. The MIG will replace them.", len(state.Instances), state.Location, state.MigName),
+			Message: fmt.Sprintf("Recreation requested for %d instance(s) in MIG %s/%s. The MIG's targetSize is preserved.", len(state.Instances), state.Location, state.MigName),
 		}}),
 	}, nil
 }

--- a/extnat/nat_attack_disassociate.go
+++ b/extnat/nat_attack_disassociate.go
@@ -213,6 +213,11 @@ func (a *cloudNatDisassociateAttack) Stop(ctx context.Context, state *CloudNatDi
 // removeNat fetches the router, drops the target NAT from its Nats[] list,
 // and PATCHes. Other NATs sharing the router stay untouched. Re-fetch on
 // every call to survive concurrent edits to sibling NATs.
+//
+// Idempotent: if the NAT is already gone (Start retried after a successful
+// removal), we return nil rather than erroring — the desired end state
+// (NAT absent) is already achieved. Mirrors restoreNat's replace-or-append
+// symmetry.
 func removeNat(ctx context.Context, provider func(ctx context.Context, projectID string) (*compute.RoutersClient, func(), error), state *CloudNatDisassociateState) error {
 	client, closer, err := provider(ctx, state.ProjectID)
 	if err != nil {
@@ -233,9 +238,9 @@ func removeNat(ctx context.Context, provider func(ctx context.Context, projectID
 		kept = append(kept, nat)
 	}
 	if !found {
-		// The NAT was there at Prepare but is gone now (renamed/deleted).
-		// Report explicitly so the caller doesn't PATCH a no-op and claim success.
-		return fmt.Errorf("cloud NAT %q not found on router %q — refusing to PATCH unchanged", state.NatName, state.RouterName)
+		// Already removed by a prior Start invocation — nothing to do.
+		log.Info().Msgf("Cloud NAT %s/%s already absent — treating remove as no-op success", state.RouterName, state.NatName)
+		return nil
 	}
 	router.Nats = kept
 	_, err = client.Patch(ctx, &computepb.PatchRouterRequest{

--- a/extnat/nat_attack_disassociate.go
+++ b/extnat/nat_attack_disassociate.go
@@ -17,24 +17,22 @@ import (
 	extension_kit "github.com/steadybit/extension-kit"
 	"github.com/steadybit/extension-kit/extbuild"
 	"github.com/steadybit/extension-kit/extutil"
+	"google.golang.org/protobuf/proto"
 )
 
-// CloudNatDisassociateState captures the original subnetworks of the target Cloud NAT so we can restore
-// them on stop. We only mutate the NAT we own; other NATs sharing the same router are preserved verbatim.
+// CloudNatDisassociateState captures the entire original NAT proto so the
+// attack can restore it byte-identically on stop. We serialise via proto.Marshal
+// (base64 in JSON) rather than snapshotting individual fields because a
+// LIST_OF_SUBNETWORKS NAT can't survive an empty subnetworks list — the only
+// way to disassociate a NAT from all its subnetworks in GCP is to remove the
+// NAT entry from the router entirely, then re-add it.
 type CloudNatDisassociateState struct {
-	ProjectID  string
-	Region     string
-	RouterName string
-	NatName    string
-	// OriginalSubnetworks are protobuf-serializable copies of the NAT's original subnetwork entries.
-	OriginalSubnetworks []natSubnetSnapshot
-}
-
-// natSubnetSnapshot mirrors the parts of computepb.RouterNatSubnetworkToNat that the attack restores.
-type natSubnetSnapshot struct {
-	Name                  string
-	SecondaryIPRangeNames []string
-	SourceIPRangesToNat   []string
+	ProjectID    string
+	Region       string
+	RouterName   string
+	NatName      string
+	NatSnapshot  []byte // proto.Marshal of the original computepb.RouterNat
+	SubnetCount  int    // for informational messages
 }
 
 type cloudNatDisassociateAttack struct {
@@ -66,11 +64,11 @@ func (a *cloudNatDisassociateAttack) NewEmptyState() CloudNatDisassociateState {
 
 func (a *cloudNatDisassociateAttack) Describe() action_kit_api.ActionDescription {
 	return action_kit_api.ActionDescription{
-		Id:    CloudNatDisassociateActionId,
-		Label: "Disassociate Cloud NAT from its subnetworks",
-		Description: "Removes all subnetworks from a Cloud NAT so VMs in those subnets lose internet egress. Restored on stop.",
-		Version: extbuild.GetSemverVersionStringOrUnknown(),
-		Icon:    extutil.Ptr(targetIcon),
+		Id:          CloudNatDisassociateActionId,
+		Label:       "Disassociate Cloud NAT from its subnetworks",
+		Description: "Removes the Cloud NAT so VMs in its subnetworks lose internet egress. Restored on stop.",
+		Version:     extbuild.GetSemverVersionStringOrUnknown(),
+		Icon:        extutil.Ptr(targetIcon),
 		TargetSelection: extutil.Ptr(action_kit_api.TargetSelection{
 			TargetType: TargetIDCloudNat,
 			SelectionTemplates: extutil.Ptr([]action_kit_api.TargetSelectionTemplate{
@@ -89,7 +87,7 @@ func (a *cloudNatDisassociateAttack) Describe() action_kit_api.ActionDescription
 			{
 				Name:         "duration",
 				Label:        "Duration",
-				Description:  extutil.Ptr("How long subnetworks remain disassociated from the Cloud NAT. Restored on stop."),
+				Description:  extutil.Ptr("How long the Cloud NAT stays removed. Restored on stop."),
 				Type:         action_kit_api.ActionParameterTypeDuration,
 				DefaultValue: extutil.Ptr("60s"),
 				Order:        extutil.Ptr(1),
@@ -108,18 +106,20 @@ func (a *cloudNatDisassociateAttack) Prepare(ctx context.Context, state *CloudNa
 	if err != nil {
 		return nil, err
 	}
-	found, snapshots := snapshotNatSubnetworks(router, state.NatName)
-	if !found {
+	nat := findNat(router, state.NatName)
+	if nat == nil {
 		return nil, extension_kit.ToError(fmt.Sprintf("Cloud NAT %s/%s not found on router — cannot disassociate", state.RouterName, state.NatName), nil)
 	}
-	if len(snapshots) == 0 {
-		return nil, extension_kit.ToError(fmt.Sprintf("Cloud NAT %s/%s has no subnetworks to disassociate", state.RouterName, state.NatName), nil)
+	blob, err := proto.Marshal(nat)
+	if err != nil {
+		return nil, extension_kit.ToError(fmt.Sprintf("Failed to snapshot Cloud NAT %s/%s config", state.RouterName, state.NatName), err)
 	}
-	state.OriginalSubnetworks = snapshots
+	state.NatSnapshot = blob
+	state.SubnetCount = len(nat.GetSubnetworks())
 	return &action_kit_api.PrepareResult{
 		Messages: extutil.Ptr([]action_kit_api.Message{{
 			Level:   extutil.Ptr(action_kit_api.Info),
-			Message: fmt.Sprintf("Will disassociate %d subnetwork(s) from Cloud NAT %s/%s", len(state.OriginalSubnetworks), state.RouterName, state.NatName),
+			Message: fmt.Sprintf("Will remove Cloud NAT %s/%s (currently attached to %d subnetwork(s))", state.RouterName, state.NatName, state.SubnetCount),
 		}}),
 	}, nil
 }
@@ -148,61 +148,47 @@ func fetchRouter(ctx context.Context, provider func(ctx context.Context, project
 	return router, nil
 }
 
-// snapshotNatSubnetworks locates the named NAT on the router and returns a
-// copy of its subnetworks list. `found` reports whether the NAT existed at all
-// so the caller can distinguish "NAT gone" from "NAT present but empty".
-func snapshotNatSubnetworks(router *computepb.Router, natName string) (found bool, snapshots []natSubnetSnapshot) {
+// findNat returns the NAT with the given name from the router, or nil if
+// absent. Cloud NAT config lives as a repeated field on the router, so we
+// scan by name.
+func findNat(router *computepb.Router, natName string) *computepb.RouterNat {
 	for _, nat := range router.GetNats() {
-		if nat.GetName() != natName {
-			continue
+		if nat.GetName() == natName {
+			return nat
 		}
-		found = true
-		for _, s := range nat.GetSubnetworks() {
-			if s == nil {
-				continue
-			}
-			snap := natSubnetSnapshot{}
-			if s.Name != nil {
-				snap.Name = *s.Name
-			}
-			snap.SecondaryIPRangeNames = append(snap.SecondaryIPRangeNames, s.GetSecondaryIpRangeNames()...)
-			snap.SourceIPRangesToNat = append(snap.SourceIPRangesToNat, s.GetSourceIpRangesToNat()...)
-			snapshots = append(snapshots, snap)
-		}
-		return found, snapshots
 	}
-	return false, nil
+	return nil
 }
 
 func (a *cloudNatDisassociateAttack) Start(ctx context.Context, state *CloudNatDisassociateState) (*action_kit_api.StartResult, error) {
-	if err := setNatSubnetworks(ctx, a.clientProvider, state, nil); err != nil {
-		return nil, extension_kit.ToError(fmt.Sprintf("Failed to disassociate Cloud NAT %s/%s subnetworks", state.RouterName, state.NatName), err)
+	if err := removeNat(ctx, a.clientProvider, state); err != nil {
+		return nil, extension_kit.ToError(fmt.Sprintf("Failed to remove Cloud NAT %s/%s", state.RouterName, state.NatName), err)
 	}
 	return &action_kit_api.StartResult{
 		Messages: extutil.Ptr([]action_kit_api.Message{{
 			Level:   extutil.Ptr(action_kit_api.Info),
-			Message: fmt.Sprintf("Disassociated %d subnetwork(s) from Cloud NAT %s/%s", len(state.OriginalSubnetworks), state.RouterName, state.NatName),
+			Message: fmt.Sprintf("Removed Cloud NAT %s/%s (was attached to %d subnetwork(s)); traffic in those subnets loses NAT egress until Stop restores it", state.RouterName, state.NatName, state.SubnetCount),
 		}}),
 	}, nil
 }
 
 func (a *cloudNatDisassociateAttack) Stop(ctx context.Context, state *CloudNatDisassociateState) (*action_kit_api.StopResult, error) {
-	if err := setNatSubnetworks(ctx, a.clientProvider, state, state.OriginalSubnetworks); err != nil {
-		log.Error().Err(err).Msgf("Failed to restore Cloud NAT %s/%s subnetworks", state.RouterName, state.NatName)
-		return nil, extension_kit.ToError(fmt.Sprintf("Failed to restore Cloud NAT %s/%s subnetworks", state.RouterName, state.NatName), err)
+	if err := restoreNat(ctx, a.clientProvider, state); err != nil {
+		log.Error().Err(err).Msgf("Failed to restore Cloud NAT %s/%s", state.RouterName, state.NatName)
+		return nil, extension_kit.ToError(fmt.Sprintf("Failed to restore Cloud NAT %s/%s", state.RouterName, state.NatName), err)
 	}
 	return &action_kit_api.StopResult{
 		Messages: extutil.Ptr([]action_kit_api.Message{{
 			Level:   extutil.Ptr(action_kit_api.Info),
-			Message: fmt.Sprintf("Restored %d subnetwork(s) on Cloud NAT %s/%s", len(state.OriginalSubnetworks), state.RouterName, state.NatName),
+			Message: fmt.Sprintf("Restored Cloud NAT %s/%s (%d subnetwork(s))", state.RouterName, state.NatName, state.SubnetCount),
 		}}),
 	}, nil
 }
 
-// setNatSubnetworks re-fetches the router and PATCHes it with the target NAT's subnetworks set to the
-// given snapshot list. Other NATs on the router are preserved verbatim. Re-fetch protects concurrent edits
-// to other NATs (or the same NAT's other fields like nat-ips) — we only own the subnetworks list of one NAT.
-func setNatSubnetworks(ctx context.Context, provider func(ctx context.Context, projectID string) (*compute.RoutersClient, func(), error), state *CloudNatDisassociateState, target []natSubnetSnapshot) error {
+// removeNat fetches the router, drops the target NAT from its Nats[] list,
+// and PATCHes. Other NATs sharing the router stay untouched. Re-fetch on
+// every call to survive concurrent edits to sibling NATs.
+func removeNat(ctx context.Context, provider func(ctx context.Context, projectID string) (*compute.RoutersClient, func(), error), state *CloudNatDisassociateState) error {
 	client, closer, err := provider(ctx, state.ProjectID)
 	if err != nil {
 		return err
@@ -212,22 +198,21 @@ func setNatSubnetworks(ctx context.Context, provider func(ctx context.Context, p
 	if err != nil {
 		return fmt.Errorf("get router: %w", err)
 	}
-	natFound := false
+	kept := make([]*computepb.RouterNat, 0, len(router.GetNats()))
+	found := false
 	for _, nat := range router.GetNats() {
-		if nat.GetName() != state.NatName {
+		if nat.GetName() == state.NatName {
+			found = true
 			continue
 		}
-		nat.Subnetworks = toSubnetworkProtos(target)
-		natFound = true
-		break
+		kept = append(kept, nat)
 	}
-	if !natFound {
-		// The NAT was present at Prepare but is gone now (renamed / deleted).
-		// Refuse to PATCH the router unchanged — the caller reports "success"
-		// otherwise and any previously-disassociated subnetworks would stay
-		// disassociated indefinitely without an error signal to the user.
+	if !found {
+		// The NAT was there at Prepare but is gone now (renamed/deleted).
+		// Report explicitly so the caller doesn't PATCH a no-op and claim success.
 		return fmt.Errorf("cloud NAT %q not found on router %q — refusing to PATCH unchanged", state.NatName, state.RouterName)
 	}
+	router.Nats = kept
 	_, err = client.Patch(ctx, &computepb.PatchRouterRequest{
 		Project:        state.ProjectID,
 		Region:         state.Region,
@@ -237,27 +222,44 @@ func setNatSubnetworks(ctx context.Context, provider func(ctx context.Context, p
 	return err
 }
 
-func toSubnetworkProtos(snapshots []natSubnetSnapshot) []*computepb.RouterNatSubnetworkToNat {
-	if len(snapshots) == 0 {
-		return []*computepb.RouterNatSubnetworkToNat{}
+// restoreNat fetches the router and re-appends the snapshotted NAT. If a NAT
+// with the same name already exists (e.g. Stop retried after a partial
+// success), replace it with the snapshot rather than duplicating.
+func restoreNat(ctx context.Context, provider func(ctx context.Context, projectID string) (*compute.RoutersClient, func(), error), state *CloudNatDisassociateState) error {
+	if len(state.NatSnapshot) == 0 {
+		return fmt.Errorf("no NAT snapshot to restore")
 	}
-	out := make([]*computepb.RouterNatSubnetworkToNat, 0, len(snapshots))
-	for i := range snapshots {
-		s := snapshots[i]
-		entry := &computepb.RouterNatSubnetworkToNat{}
-		if s.Name != "" {
-			n := s.Name
-			entry.Name = &n
-		}
-		if len(s.SecondaryIPRangeNames) > 0 {
-			entry.SecondaryIpRangeNames = append([]string(nil), s.SecondaryIPRangeNames...)
-		}
-		if len(s.SourceIPRangesToNat) > 0 {
-			entry.SourceIpRangesToNat = append([]string(nil), s.SourceIPRangesToNat...)
-		}
-		out = append(out, entry)
+	original := &computepb.RouterNat{}
+	if err := proto.Unmarshal(state.NatSnapshot, original); err != nil {
+		return fmt.Errorf("unmarshal NAT snapshot: %w", err)
 	}
-	return out
+	client, closer, err := provider(ctx, state.ProjectID)
+	if err != nil {
+		return err
+	}
+	defer closer()
+	router, err := client.Get(ctx, &computepb.GetRouterRequest{Project: state.ProjectID, Region: state.Region, Router: state.RouterName})
+	if err != nil {
+		return fmt.Errorf("get router: %w", err)
+	}
+	replaced := false
+	for i, nat := range router.GetNats() {
+		if nat.GetName() == state.NatName {
+			router.Nats[i] = original
+			replaced = true
+			break
+		}
+	}
+	if !replaced {
+		router.Nats = append(router.Nats, original)
+	}
+	_, err = client.Patch(ctx, &computepb.PatchRouterRequest{
+		Project:        state.ProjectID,
+		Region:         state.Region,
+		Router:         state.RouterName,
+		RouterResource: router,
+	})
+	return err
 }
 
 func mustHave(attrs map[string][]string, key string) string {

--- a/extnat/nat_attack_disassociate.go
+++ b/extnat/nat_attack_disassociate.go
@@ -27,12 +27,19 @@ import (
 // way to disassociate a NAT from all its subnetworks in GCP is to remove the
 // NAT entry from the router entirely, then re-add it.
 type CloudNatDisassociateState struct {
-	ProjectID    string
-	Region       string
-	RouterName   string
-	NatName      string
-	NatSnapshot  []byte // proto.Marshal of the original computepb.RouterNat
-	SubnetCount  int    // for informational messages
+	ProjectID   string
+	Region      string
+	RouterName  string
+	NatName     string
+	NatSnapshot []byte // proto.Marshal of the original computepb.RouterNat
+	// SourceMode is the NAT's sourceSubnetworkIpRangesToNat mode, captured for
+	// human-readable Prepare/Start/Stop messages. Set to the literal string
+	// GCP returned (e.g. LIST_OF_SUBNETWORKS, ALL_SUBNETWORKS_ALL_IP_RANGES).
+	SourceMode string
+	// SubnetCount is only meaningful when SourceMode is LIST_OF_SUBNETWORKS —
+	// the other modes NAT every subnet in the region without populating an
+	// explicit list, so this field stays 0 there.
+	SubnetCount int
 }
 
 type cloudNatDisassociateAttack struct {
@@ -115,13 +122,31 @@ func (a *cloudNatDisassociateAttack) Prepare(ctx context.Context, state *CloudNa
 		return nil, extension_kit.ToError(fmt.Sprintf("Failed to snapshot Cloud NAT %s/%s config", state.RouterName, state.NatName), err)
 	}
 	state.NatSnapshot = blob
+	state.SourceMode = nat.GetSourceSubnetworkIpRangesToNat()
 	state.SubnetCount = len(nat.GetSubnetworks())
 	return &action_kit_api.PrepareResult{
 		Messages: extutil.Ptr([]action_kit_api.Message{{
 			Level:   extutil.Ptr(action_kit_api.Info),
-			Message: fmt.Sprintf("Will remove Cloud NAT %s/%s (currently attached to %d subnetwork(s))", state.RouterName, state.NatName, state.SubnetCount),
+			Message: fmt.Sprintf("Will remove Cloud NAT %s/%s (%s)", state.RouterName, state.NatName, natCoverageDescription(state.SourceMode, state.SubnetCount)),
 		}}),
 	}, nil
+}
+
+// natCoverageDescription renders a human-readable summary of what the NAT
+// covers. For LIST_OF_SUBNETWORKS mode we can say "N subnetwork(s)"; the
+// ALL_SUBNETWORKS_* modes don't populate an explicit list, so the subnet
+// count alone would misleadingly read as zero.
+func natCoverageDescription(sourceMode string, subnetCount int) string {
+	switch sourceMode {
+	case "LIST_OF_SUBNETWORKS":
+		return fmt.Sprintf("attached to %d subnetwork(s)", subnetCount)
+	case "ALL_SUBNETWORKS_ALL_IP_RANGES":
+		return "NATs every subnetwork in the region"
+	case "ALL_SUBNETWORKS_ALL_PRIMARY_IP_RANGES":
+		return "NATs the primary IP range of every subnetwork in the region"
+	default:
+		return fmt.Sprintf("mode=%s", sourceMode)
+	}
 }
 
 func populatePrepareTarget(state *CloudNatDisassociateState, request action_kit_api.PrepareActionRequestBody) error {
@@ -167,7 +192,7 @@ func (a *cloudNatDisassociateAttack) Start(ctx context.Context, state *CloudNatD
 	return &action_kit_api.StartResult{
 		Messages: extutil.Ptr([]action_kit_api.Message{{
 			Level:   extutil.Ptr(action_kit_api.Info),
-			Message: fmt.Sprintf("Removed Cloud NAT %s/%s (was attached to %d subnetwork(s)); traffic in those subnets loses NAT egress until Stop restores it", state.RouterName, state.NatName, state.SubnetCount),
+			Message: fmt.Sprintf("Removed Cloud NAT %s/%s (%s); traffic in those subnets loses NAT egress until Stop restores it", state.RouterName, state.NatName, natCoverageDescription(state.SourceMode, state.SubnetCount)),
 		}}),
 	}, nil
 }
@@ -180,7 +205,7 @@ func (a *cloudNatDisassociateAttack) Stop(ctx context.Context, state *CloudNatDi
 	return &action_kit_api.StopResult{
 		Messages: extutil.Ptr([]action_kit_api.Message{{
 			Level:   extutil.Ptr(action_kit_api.Info),
-			Message: fmt.Sprintf("Restored Cloud NAT %s/%s (%d subnetwork(s))", state.RouterName, state.NatName, state.SubnetCount),
+			Message: fmt.Sprintf("Restored Cloud NAT %s/%s (%s)", state.RouterName, state.NatName, natCoverageDescription(state.SourceMode, state.SubnetCount)),
 		}}),
 	}, nil
 }

--- a/extnat/nat_attack_disassociate_test.go
+++ b/extnat/nat_attack_disassociate_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/steadybit/extension-kit/extutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
 )
 
 func natPrepareReq(attrs map[string][]string) action_kit_api.PrepareActionRequestBody {
@@ -22,7 +23,7 @@ func natPrepareReq(attrs map[string][]string) action_kit_api.PrepareActionReques
 }
 
 var validNatAttrs = map[string][]string{
-	"gcp.project.id":     {"proj-a"},
+	"gcp.project.id":       {"proj-a"},
 	"gcp.cloud-nat.region": {"europe-west1"},
 	"gcp.cloud-nat.router": {"main-router"},
 	"gcp.cloud-nat.name":   {"main-nat"},
@@ -58,64 +59,31 @@ func TestNatDisassociate_NewAction(t *testing.T) {
 	assert.NotNil(t, a)
 }
 
-func TestToSubnetworkProtos(t *testing.T) {
-	snaps := []natSubnetSnapshot{
-		{Name: "subnet-a", SourceIPRangesToNat: []string{"ALL_IP_RANGES"}},
-		{Name: "subnet-b", SecondaryIPRangeNames: []string{"secondary-1"}},
+func TestFindNat_Found(t *testing.T) {
+	target := &computepb.RouterNat{
+		Name: ptr("target-nat"),
+		Subnetworks: []*computepb.RouterNatSubnetworkToNat{
+			{Name: ptr("subnet-a"), SourceIpRangesToNat: []string{"ALL_IP_RANGES"}},
+			{Name: ptr("subnet-b"), SecondaryIpRangeNames: []string{"secondary-1"}},
+		},
 	}
-	protos := toSubnetworkProtos(snaps)
-	require.Len(t, protos, 2)
-
-	// Reconstruct back for a round-trip sanity check on the pointer marshalling.
-	assert.Equal(t, "subnet-a", *protos[0].Name)
-	assert.Equal(t, []string{"ALL_IP_RANGES"}, protos[0].SourceIpRangesToNat)
-	assert.Equal(t, "subnet-b", *protos[1].Name)
-	assert.Equal(t, []string{"secondary-1"}, protos[1].SecondaryIpRangeNames)
-}
-
-// Compile-time coverage: this pulls in the RouterNat proto type to make sure
-// natSubnetSnapshot struct changes stay proto-compatible.
-var _ = &computepb.RouterNat{}
-
-func TestSnapshotNatSubnetworks_Found(t *testing.T) {
 	router := &computepb.Router{
 		Nats: []*computepb.RouterNat{
 			{Name: ptr("other-nat"), Subnetworks: []*computepb.RouterNatSubnetworkToNat{{Name: ptr("other-subnet")}}},
-			{
-				Name: ptr("target-nat"),
-				Subnetworks: []*computepb.RouterNatSubnetworkToNat{
-					{Name: ptr("subnet-a"), SourceIpRangesToNat: []string{"ALL_IP_RANGES"}},
-					nil,
-					{Name: ptr("subnet-b"), SecondaryIpRangeNames: []string{"secondary-1"}},
-				},
-			},
+			target,
 		},
 	}
-	found, snaps := snapshotNatSubnetworks(router, "target-nat")
-	assert.True(t, found)
-	require.Len(t, snaps, 2)
-	assert.Equal(t, "subnet-a", snaps[0].Name)
-	assert.Equal(t, []string{"ALL_IP_RANGES"}, snaps[0].SourceIPRangesToNat)
-	assert.Equal(t, "subnet-b", snaps[1].Name)
-	assert.Equal(t, []string{"secondary-1"}, snaps[1].SecondaryIPRangeNames)
+	nat := findNat(router, "target-nat")
+	require.NotNil(t, nat)
+	assert.Equal(t, "target-nat", nat.GetName())
+	assert.Len(t, nat.GetSubnetworks(), 2)
 }
 
-func TestSnapshotNatSubnetworks_NotFound(t *testing.T) {
+func TestFindNat_NotFound(t *testing.T) {
 	router := &computepb.Router{
 		Nats: []*computepb.RouterNat{{Name: ptr("other-nat")}},
 	}
-	found, snaps := snapshotNatSubnetworks(router, "missing")
-	assert.False(t, found)
-	assert.Nil(t, snaps)
-}
-
-func TestSnapshotNatSubnetworks_FoundButEmpty(t *testing.T) {
-	router := &computepb.Router{
-		Nats: []*computepb.RouterNat{{Name: ptr("solo")}},
-	}
-	found, snaps := snapshotNatSubnetworks(router, "solo")
-	assert.True(t, found)
-	assert.Empty(t, snaps)
+	assert.Nil(t, findNat(router, "missing"))
 }
 
 func TestPopulatePrepareTarget(t *testing.T) {
@@ -131,3 +99,40 @@ func TestPopulatePrepareTarget(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "missing")
 }
+
+// TestNatSnapshotRoundTrip verifies proto.Marshal → proto.Unmarshal round-trips
+// preserve every NAT field the attack cares about — otherwise Stop would
+// restore a subtly-different NAT than Prepare captured.
+func TestNatSnapshotRoundTrip(t *testing.T) {
+	original := &computepb.RouterNat{
+		Name:                          ptr("prod-nat"),
+		SourceSubnetworkIpRangesToNat: ptr("LIST_OF_SUBNETWORKS"),
+		NatIpAllocateOption:           ptr("MANUAL_ONLY"),
+		NatIps:                        []string{"projects/p/regions/r/addresses/nat-ip-1"},
+		Subnetworks: []*computepb.RouterNatSubnetworkToNat{
+			{Name: ptr("subnet-a"), SourceIpRangesToNat: []string{"ALL_IP_RANGES"}},
+			{Name: ptr("subnet-b"), SecondaryIpRangeNames: []string{"secondary-1"}},
+		},
+		MinPortsPerVm: ptrI32(64),
+		LogConfig:     &computepb.RouterNatLogConfig{Enable: ptrBool(true)},
+	}
+
+	blob, err := proto.Marshal(original)
+	require.NoError(t, err)
+	require.NotEmpty(t, blob)
+
+	restored := &computepb.RouterNat{}
+	require.NoError(t, proto.Unmarshal(blob, restored))
+
+	// proto.Equal ignores nil vs empty-slice subtleties and does the deep
+	// comparison we actually care about.
+	assert.True(t, proto.Equal(original, restored), "restored NAT differs from original")
+	// Belt-and-suspenders spot checks in case proto.Equal is too lenient.
+	assert.Equal(t, "prod-nat", restored.GetName())
+	assert.Equal(t, "LIST_OF_SUBNETWORKS", restored.GetSourceSubnetworkIpRangesToNat())
+	assert.Len(t, restored.GetSubnetworks(), 2)
+	assert.Equal(t, "subnet-a", restored.GetSubnetworks()[0].GetName())
+	assert.Equal(t, int32(64), restored.GetMinPortsPerVm())
+}
+
+func ptrBool(b bool) *bool { return &b }


### PR DESCRIPTION
Three attack-implementation fixes surfaced by running the experiments live on \`demo-develop-demo\`.

## 1. Cloud NAT disassociate — 100% failing at Start

GCP rejects \`nat.Subnetworks=[]\` on any NAT with \`sourceSubnetworkIpRangesToNat=LIST_OF_SUBNETWORKS\`:

\`\`\`
Failed to disassociate Cloud NAT weekly-tests-router/weekly-tests-nat subnetworks:
googleapi: Error 400: Invalid value for field 'resource.nats[0].subnetworks': ''.
Must provide some subnetworks if Nat is configured with option LIST_OF_SUBNETWORKS.
\`\`\`

Root cause: there is no such thing as "empty subnetworks list" in that NAT mode. The attack was trying to do something GCP structurally disallows.

**Fix**: remove the whole NAT from \`router.Nats[]\` on Start; re-append the snapshotted NAT on Stop. Snapshot uses \`proto.Marshal\` → \`[]byte\` in state so restore is byte-identical (mode, IPs, log config, min-ports-per-vm — the old snapshot lost all those). Stop is idempotent: if a NAT with the same name already exists at restore time (Stop retried after partial success), it's replaced with the snapshot rather than duplicated.

## 2. MIG delete-instances — leaves the MIG permanently undersized

Confirmed live: MIG delete-instances at 50% on a 2-instance MIG left \`targetSize=1\` afterwards. Per Google's docs, \`deleteInstances\` "reduces the targetSize of the managed instance group by the number of instances that you delete." The old attack description promised the MIG would "recreate replacements per its scaling/heal policies" — but that only happens when an autoscaler is bound. For fixed-size MIGs (the common case, including the \`gcp-weekly-tests\` fixture), the pool stays permanently undersized after every experiment.

**Fix**: switch to \`recreateInstances\`, which per Google:

> Flags the specified VM instances in the managed instance group to be immediately recreated. Each instance is verified and restarted individually. **The recreation preserves the MIG's \`targetSize\`.**

Chaos signal preserved (VMs go down, get new hardware identity, pods reschedule), operational footgun removed.

## 3. GKE nodepool terminate-instances — same footgun

The GKE terminate-instances attack delegates to the underlying MIG's \`DeleteInstances\`, so it had the same targetSize-shrink bug. Same fix: switch to \`RecreateInstances\` on the underlying MIG.

## Behaviour delta at a glance

| | Before | After |
|---|---|---|
| Cloud NAT disassociate Start | ❌ 400 error | ✅ NAT removed |
| Cloud NAT disassociate Stop | Restored 3 subnetwork fields | Restored full NAT proto |
| MIG delete-instances \`targetSize\` | Reduced | Preserved |
| GKE terminate-instances node pool size | Reduced | Preserved |
| Selected VMs killed / pods reschedule | ✅ | ✅ |

## API-level changes

- \`compute.RouterNat\` snapshot via \`proto.Marshal\` (new dependency on \`google.golang.org/protobuf/proto\`)
- \`compute.InstanceGroupManagers.DeleteInstances\` → \`RecreateInstances\` (both zonal and regional)

Action IDs kept unchanged (\`cloud-nat.disassociate-subnets\`, \`mig.delete-instances\`, \`gke.nodepool.terminate-instances\`) so any tooling referencing them keeps working. Labels + descriptions + messages updated to reflect the new semantics.

## Test plan

- [x] \`go build ./...\` / \`go vet ./...\` clean
- [x] All existing tests pass; new tests added for the NAT proto round-trip and the \`findNat\` helper (11 \`extnat\` tests total)
- [ ] After merge + chart bump on \`demo-develop-demo\`, re-run each experiment:
  - Cloud NAT: Start should succeed (NAT removed); Stop should recreate it
  - MIG delete-instances at 50% on 2-instance MIG: \`targetSize\` should stay at 2
  - GKE terminate-instances on the chaos pool: pool size should stay at 2

Supersedes #382 (now folded into this PR).