### PR TITLE
fix(mig,gke): recreate instances instead of deleting them

### DIFF
--- a/extgke/nodepool_attack_terminate_instances.go
+++ b/extgke/nodepool_attack_terminate_instances.go
@@ -43,7 +43,7 @@ type NodePoolTerminateInstancesState struct {
 
 type migInstancesApi interface {
 	ListManagedInstances(ctx context.Context, req *computepb.ListManagedInstancesInstanceGroupManagersRequest, opts ...gax.CallOption) *compute.ManagedInstanceIterator
-	DeleteInstances(ctx context.Context, req *computepb.DeleteInstancesInstanceGroupManagerRequest, opts ...gax.CallOption) (*compute.Operation, error)
+	RecreateInstances(ctx context.Context, req *computepb.RecreateInstancesInstanceGroupManagerRequest, opts ...gax.CallOption) (*compute.Operation, error)
 }
 
 type nodePoolTerminateInstancesAttack struct {
@@ -77,8 +77,8 @@ func (a *nodePoolTerminateInstancesAttack) NewEmptyState() NodePoolTerminateInst
 func (a *nodePoolTerminateInstancesAttack) Describe() action_kit_api.ActionDescription {
 	return action_kit_api.ActionDescription{
 		Id:    NodePoolTerminateInstancesActionId,
-		Label: "Terminate GKE node pool instances",
-		Description: "Deletes a percentage of instances from a GKE node pool via the underlying MIG. Not reversible — MIG scaling recreates replacements.",
+		Label: "Recreate GKE node pool instances",
+		Description: "Recreates a percentage of node instances in a GKE node pool via the underlying MIG's RecreateInstances API. The node pool's size is preserved (unlike deleteInstances, which shrinks the MIG). Pods reschedule onto surviving or freshly-recreated nodes. Not reversible.",
 		Version: extbuild.GetSemverVersionStringOrUnknown(),
 		Icon:    extutil.Ptr(targetIcon),
 		TargetSelection: extutil.Ptr(action_kit_api.TargetSelection{
@@ -240,7 +240,7 @@ func (a *nodePoolTerminateInstancesAttack) Prepare(ctx context.Context, state *N
 
 func (a *nodePoolTerminateInstancesAttack) Start(ctx context.Context, state *NodePoolTerminateInstancesState) (*action_kit_api.StartResult, error) {
 	if len(state.InstancesByMig) == 0 {
-		return nil, extension_kit.ToError("No instances selected for termination.", nil)
+		return nil, extension_kit.ToError("No instances selected for recreation.", nil)
 	}
 	client, closer, err := a.migClientProvider(ctx, state.ProjectID)
 	if err != nil {
@@ -250,23 +250,23 @@ func (a *nodePoolTerminateInstancesAttack) Start(ctx context.Context, state *Nod
 	total := 0
 	for key, urls := range state.InstancesByMig {
 		zone, name, _ := strings.Cut(key, "/")
-		_, err := client.DeleteInstances(ctx, &computepb.DeleteInstancesInstanceGroupManagerRequest{
+		_, err := client.RecreateInstances(ctx, &computepb.RecreateInstancesInstanceGroupManagerRequest{
 			Project:              state.ProjectID,
 			Zone:                 zone,
 			InstanceGroupManager: name,
-			InstanceGroupManagersDeleteInstancesRequestResource: &computepb.InstanceGroupManagersDeleteInstancesRequest{
+			InstanceGroupManagersRecreateInstancesRequestResource: &computepb.InstanceGroupManagersRecreateInstancesRequest{
 				Instances: urls,
 			},
 		})
 		if err != nil {
-			return nil, extension_kit.ToError(fmt.Sprintf("Failed to delete instances from MIG %s/%s", zone, name), err)
+			return nil, extension_kit.ToError(fmt.Sprintf("Failed to recreate instances in MIG %s/%s", zone, name), err)
 		}
 		total += len(urls)
 	}
 	return &action_kit_api.StartResult{
 		Messages: extutil.Ptr([]action_kit_api.Message{{
 			Level:   extutil.Ptr(action_kit_api.Info),
-			Message: fmt.Sprintf("Deletion requested for %d instance(s) in GKE node pool %s/%s. GKE will replace them via the underlying MIG.", total, state.ClusterName, state.NodePoolName),
+			Message: fmt.Sprintf("Recreation requested for %d instance(s) in GKE node pool %s/%s. The node pool's size is preserved.", total, state.ClusterName, state.NodePoolName),
 		}}),
 	}, nil
 }

--- a/extmig/mig_attack_delete_instances.go
+++ b/extmig/mig_attack_delete_instances.go
@@ -23,11 +23,12 @@ import (
 	"google.golang.org/api/iterator"
 )
 
-// MigDeleteInstancesState holds the sampled instance URLs to delete on Start.
-// This attack is destructive and is NOT reversible: deleted instances are gone; the MIG creates new
-// replacements per its scaling/heal policies. Recovery time depends on the MIG's autoscaler / surge
-// configuration; a MIG with autoscaling disabled and targetSize manually managed will stay undersized
-// until an operator intervenes.
+// MigDeleteInstancesState holds the sampled instance URLs to recreate on Start.
+// This attack calls the MIG's RecreateInstances API — the target VMs are deleted and replaced from the
+// current instance template. Unlike DeleteInstances, RecreateInstances preserves the MIG's targetSize,
+// so an autoscaler-free MIG (like a fixed-size stateful pool) doesn't stay undersized after the attack.
+// The VMs get new hardware identity (new instance IDs, boot times) but keep their names and any
+// stateful-policy state.
 type MigDeleteInstancesState struct {
 	ProjectID  string
 	Scope      string // "zonal" or "regional"
@@ -45,12 +46,12 @@ type migDeleteInstancesAttack struct {
 
 type zonalMigApi interface {
 	ListManagedInstances(ctx context.Context, req *computepb.ListManagedInstancesInstanceGroupManagersRequest, opts ...gaxOpt) *compute.ManagedInstanceIterator
-	DeleteInstances(ctx context.Context, req *computepb.DeleteInstancesInstanceGroupManagerRequest, opts ...gaxOpt) (*compute.Operation, error)
+	RecreateInstances(ctx context.Context, req *computepb.RecreateInstancesInstanceGroupManagerRequest, opts ...gaxOpt) (*compute.Operation, error)
 }
 
 type regionalMigApi interface {
 	ListManagedInstances(ctx context.Context, req *computepb.ListManagedInstancesRegionInstanceGroupManagersRequest, opts ...gaxOpt) *compute.ManagedInstanceIterator
-	DeleteInstances(ctx context.Context, req *computepb.DeleteInstancesRegionInstanceGroupManagerRequest, opts ...gaxOpt) (*compute.Operation, error)
+	RecreateInstances(ctx context.Context, req *computepb.RecreateInstancesRegionInstanceGroupManagerRequest, opts ...gaxOpt) (*compute.Operation, error)
 }
 
 // gaxOpt is a local alias for gax.CallOption keeping the interfaces above terse.
@@ -93,8 +94,8 @@ func (a *migDeleteInstancesAttack) NewEmptyState() MigDeleteInstancesState {
 func (a *migDeleteInstancesAttack) Describe() action_kit_api.ActionDescription {
 	return action_kit_api.ActionDescription{
 		Id:    MigDeleteInstancesActionId,
-		Label: "Delete MIG instances",
-		Description: "Deletes a percentage of RUNNING instances from a Managed Instance Group. Not reversible — MIG scaling recreates replacements.",
+		Label: "Recreate MIG instances",
+		Description: "Recreates a percentage of RUNNING instances in a Managed Instance Group. The MIG's targetSize is preserved (unlike deleteInstances, which shrinks it). Not reversible.",
 		Version: extbuild.GetSemverVersionStringOrUnknown(),
 		Icon:    extutil.Ptr(targetIcon),
 		TargetSelection: extutil.Ptr(action_kit_api.TargetSelection{
@@ -114,8 +115,8 @@ func (a *migDeleteInstancesAttack) Describe() action_kit_api.ActionDescription {
 		Parameters: []action_kit_api.ActionParameter{
 			{
 				Name:         "percentage",
-				Label:        "Percentage of instances to delete",
-				Description:  extutil.Ptr("Percentage (1-100) of MIG's RUNNING instances to delete. Defaults to 33%."),
+				Label:        "Percentage of instances to recreate",
+				Description:  extutil.Ptr("Percentage (1-100) of MIG's RUNNING instances to recreate. Defaults to 33%."),
 				Type:         action_kit_api.ActionParameterTypeInteger,
 				DefaultValue: extutil.Ptr("33"),
 				Order:        extutil.Ptr(1),
@@ -126,7 +127,7 @@ func (a *migDeleteInstancesAttack) Describe() action_kit_api.ActionDescription {
 			{
 				Name:         "confirmHighImpact",
 				Label:        "Allow percentages above 50%",
-				Description:  extutil.Ptr("Required to enable percentages above 50%. Acknowledges that more than half the MIG will be deleted simultaneously."),
+				Description:  extutil.Ptr("Required to enable percentages above 50%. Acknowledges that more than half the MIG will be recreated simultaneously."),
 				Type:         action_kit_api.ActionParameterTypeBoolean,
 				DefaultValue: extutil.Ptr("false"),
 				Order:        extutil.Ptr(2),
@@ -150,7 +151,7 @@ func (a *migDeleteInstancesAttack) Prepare(ctx context.Context, state *MigDelete
 	}
 	confirmHigh := extutil.ToBool(request.Config["confirmHighImpact"])
 	if pct > 50 && !confirmHigh {
-		return nil, extension_kit.ToError("Percentages above 50% require the 'Allow percentages above 50%' flag — half the MIG will be deleted at once.", nil)
+		return nil, extension_kit.ToError("Percentages above 50% require the 'Allow percentages above 50%' flag — half the MIG will be recreated at once.", nil)
 	}
 	state.Percentage = pct
 
@@ -159,7 +160,7 @@ func (a *migDeleteInstancesAttack) Prepare(ctx context.Context, state *MigDelete
 		return nil, extension_kit.ToError(fmt.Sprintf("Failed to list MIG instances for %s/%s", state.Location, state.MigName), err)
 	}
 	if len(allInstances) == 0 {
-		return nil, extension_kit.ToError(fmt.Sprintf("MIG %s/%s has no RUNNING instances to delete", state.Location, state.MigName), nil)
+		return nil, extension_kit.ToError(fmt.Sprintf("MIG %s/%s has no RUNNING instances to recreate", state.Location, state.MigName), nil)
 	}
 	sort.Strings(allInstances)
 	// Use math.Floor (not math.Ceil) so the sample never exceeds the requested
@@ -191,7 +192,7 @@ func (a *migDeleteInstancesAttack) Prepare(ctx context.Context, state *MigDelete
 	return &action_kit_api.PrepareResult{
 		Messages: extutil.Ptr([]action_kit_api.Message{{
 			Level:   extutil.Ptr(action_kit_api.Info),
-			Message: fmt.Sprintf("Selected %d of %d RUNNING instance(s) (%d%%) in MIG %s/%s for deletion", sampleSize, len(allInstances), pct, state.Location, state.MigName),
+			Message: fmt.Sprintf("Selected %d of %d RUNNING instance(s) (%d%%) in MIG %s/%s for recreation", sampleSize, len(allInstances), pct, state.Location, state.MigName),
 		}}),
 	}, nil
 }
@@ -253,7 +254,7 @@ func (a *migDeleteInstancesAttack) listRunningInstances(ctx context.Context, sta
 
 func (a *migDeleteInstancesAttack) Start(ctx context.Context, state *MigDeleteInstancesState) (*action_kit_api.StartResult, error) {
 	if len(state.Instances) == 0 {
-		return nil, extension_kit.ToError("No instances selected for deletion.", nil)
+		return nil, extension_kit.ToError("No instances selected for recreation.", nil)
 	}
 	switch state.Scope {
 	case "zonal":
@@ -262,16 +263,16 @@ func (a *migDeleteInstancesAttack) Start(ctx context.Context, state *MigDeleteIn
 			return nil, extension_kit.ToError(fmt.Sprintf("Failed to create MIG client for project %s", state.ProjectID), err)
 		}
 		defer closer()
-		_, err = client.DeleteInstances(ctx, &computepb.DeleteInstancesInstanceGroupManagerRequest{
+		_, err = client.RecreateInstances(ctx, &computepb.RecreateInstancesInstanceGroupManagerRequest{
 			Project:              state.ProjectID,
 			Zone:                 state.Location,
 			InstanceGroupManager: state.MigName,
-			InstanceGroupManagersDeleteInstancesRequestResource: &computepb.InstanceGroupManagersDeleteInstancesRequest{
+			InstanceGroupManagersRecreateInstancesRequestResource: &computepb.InstanceGroupManagersRecreateInstancesRequest{
 				Instances: state.Instances,
 			},
 		})
 		if err != nil {
-			return nil, extension_kit.ToError(fmt.Sprintf("Failed to delete instances from MIG %s/%s", state.Location, state.MigName), err)
+			return nil, extension_kit.ToError(fmt.Sprintf("Failed to recreate instances in MIG %s/%s", state.Location, state.MigName), err)
 		}
 	case "regional":
 		client, closer, err := a.regionalClientProvider(ctx, state.ProjectID)
@@ -279,16 +280,16 @@ func (a *migDeleteInstancesAttack) Start(ctx context.Context, state *MigDeleteIn
 			return nil, extension_kit.ToError(fmt.Sprintf("Failed to create regional MIG client for project %s", state.ProjectID), err)
 		}
 		defer closer()
-		_, err = client.DeleteInstances(ctx, &computepb.DeleteInstancesRegionInstanceGroupManagerRequest{
+		_, err = client.RecreateInstances(ctx, &computepb.RecreateInstancesRegionInstanceGroupManagerRequest{
 			Project:              state.ProjectID,
 			Region:               state.Location,
 			InstanceGroupManager: state.MigName,
-			RegionInstanceGroupManagersDeleteInstancesRequestResource: &computepb.RegionInstanceGroupManagersDeleteInstancesRequest{
+			RegionInstanceGroupManagersRecreateRequestResource: &computepb.RegionInstanceGroupManagersRecreateRequest{
 				Instances: state.Instances,
 			},
 		})
 		if err != nil {
-			return nil, extension_kit.ToError(fmt.Sprintf("Failed to delete instances from regional MIG %s/%s", state.Location, state.MigName), err)
+			return nil, extension_kit.ToError(fmt.Sprintf("Failed to recreate instances in regional MIG %s/%s", state.Location, state.MigName), err)
 		}
 	default:
 		return nil, extension_kit.ToError(fmt.Sprintf("unsupported MIG scope %q", state.Scope), nil)
@@ -296,7 +297,7 @@ func (a *migDeleteInstancesAttack) Start(ctx context.Context, state *MigDeleteIn
 	return &action_kit_api.StartResult{
 		Messages: extutil.Ptr([]action_kit_api.Message{{
 			Level:   extutil.Ptr(action_kit_api.Info),
-			Message: fmt.Sprintf("Deletion requested for %d instance(s) in MIG %s/%s. The MIG will replace them.", len(state.Instances), state.Location, state.MigName),
+			Message: fmt.Sprintf("Recreation requested for %d instance(s) in MIG %s/%s. The MIG's targetSize is preserved.", len(state.Instances), state.Location, state.MigName),
 		}}),
 	}, nil
 }


### PR DESCRIPTION
## Summary

Both the MIG delete-instances attack and the GKE node pool terminate-instances attack were calling GCP's \`InstanceGroupManagers.deleteInstances\` API, which — per [Google's docs](https://cloud.google.com/compute/docs/reference/rest/v1/instanceGroupManagers/deleteInstances) — decrements the MIG's \`targetSize\` by the number of instances deleted. Confirmed live: MIG delete-instances at 50 % on a 2-instance MIG left \`targetSize=1\` afterwards.

The old attack description promised the MIG would "recreate replacements per its scaling/heal policies" — but that only happens when an autoscaler is bound to the MIG. For a fixed-size MIG (common for stateful pools, and for the \`gcp-weekly-tests\` fixture), the pool stays permanently undersized after every experiment.

## Fix

Switch both attacks to the sibling API \`recreateInstances\`, which per Google:

> Flags the specified VM instances in the managed instance group to be immediately recreated. Each instance is verified and restarted individually. This operation is marked as DONE when the flag is set even if the instances have not yet been recreated. **The recreation preserves the MIG's \`targetSize\`.**

Chaos signal is preserved — VMs go down, get new hardware identity, pods reschedule. The operational footgun is removed — no manual \`resize\` needed after the experiment.

## Behaviour delta

| | Before (\`deleteInstances\`) | After (\`recreateInstances\`) |
|---|---|---|
| Selected instances killed | ✅ | ✅ |
| VMs re-provisioned from template | Only via autoscaler | ✅ Always |
| MIG \`targetSize\` after attack | **Reduced** | **Preserved** |
| Fixed-size MIG left undersized | ❌ Yes | ✅ No |
| Instance names | Different (autoscaler picks) | Same |
| Pods reschedule | ✅ | ✅ |

## API-level change

- \`compute.InstanceGroupManagers.DeleteInstances\` → \`compute.InstanceGroupManagers.RecreateInstances\`
- \`compute.RegionInstanceGroupManagers.DeleteInstances\` → \`compute.RegionInstanceGroupManagers.RecreateInstances\`

Interfaces \`zonalMigApi\`, \`regionalMigApi\`, \`migInstancesApi\` updated to declare the new method. Label / description / parameter text / prepare-start messages updated to reflect the new semantic. Action IDs kept unchanged so any tooling referencing them keeps working.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [x] Existing tests pass
- [ ] Re-run MIG experiment on demo-develop-demo — confirm \`targetSize\` stays at 2 after 50 % attack
- [ ] Re-run GKE terminate experiment on the chaos node pool — confirm the pool stays at 2 nodes