### PR TITLE
fix(cloudsql): send required FailoverContext with settingsVersion

### DIFF
--- a/extcloudsql/instance_attack_failover.go
+++ b/extcloudsql/instance_attack_failover.go
@@ -89,7 +89,24 @@ func (a *cloudSqlFailoverAttack) Start(ctx context.Context, state *CloudSqlFailo
 	if err != nil {
 		return nil, extension_kit.ToError(fmt.Sprintf("Failed to initialize Cloud SQL client for project %s", state.ProjectID), err)
 	}
-	_, err = svc.Instances.Failover(state.ProjectID, state.InstanceName, &sqladmin.InstancesFailoverRequest{}).Context(ctx).Do()
+	// The Failover API rejects an empty body with `Missing parameter: Failover
+	// Context`. The FailoverContext must carry the instance's current
+	// settingsVersion — GCP uses it as an optimistic-concurrency fingerprint
+	// and fails the request if the instance was mutated between our Get and
+	// our Failover call.
+	inst, err := svc.Instances.Get(state.ProjectID, state.InstanceName).Context(ctx).Do()
+	if err != nil {
+		return nil, extension_kit.ToError(fmt.Sprintf("Failed to fetch Cloud SQL instance %s to read settingsVersion", state.InstanceName), err)
+	}
+	if inst.Settings == nil {
+		return nil, extension_kit.ToError(fmt.Sprintf("Cloud SQL instance %s has no Settings — cannot compute failover context", state.InstanceName), nil)
+	}
+	_, err = svc.Instances.Failover(state.ProjectID, state.InstanceName, &sqladmin.InstancesFailoverRequest{
+		FailoverContext: &sqladmin.FailoverContext{
+			Kind:            "sql#failoverContext",
+			SettingsVersion: inst.Settings.SettingsVersion,
+		},
+	}).Context(ctx).Do()
 	if err != nil {
 		return nil, extension_kit.ToError(fmt.Sprintf("Failed to trigger Cloud SQL failover for %s", state.InstanceName), err)
 	}


### PR DESCRIPTION
## What

Fix the Cloud SQL failover attack (`com.steadybit.extension_gcp.cloudsql.instance.failover`). Live test on demo-develop-demo failed with:

> Failed to trigger Cloud SQL failover for weekly-tests-sql-…: googleapi: Error 400: Invalid request: **Missing parameter: Failover Context.**, invalid

## Why

The Cloud SQL Failover API rejects an empty request body. It requires a `FailoverContext` object carrying the instance's current `settingsVersion` — GCP uses that as an optimistic-concurrency fingerprint so we don't fail over an instance whose settings changed between our read and our write.

## How

`Start` now:

1. `Get` the instance to read `Settings.SettingsVersion`.
2. Send `Failover` with `FailoverContext{Kind: "sql#failoverContext", SettingsVersion: <current>}`.
3. Nil-guard `inst.Settings` so we never crash on unexpected server responses.

If the instance is mutated between the Get and the Failover call, GCP rejects the failover with a settings-version mismatch — that's the correct behavior (bail rather than fail over stale config).

## Test plan

- [ ] Deploy this branch to demo-develop-demo
- [ ] Run the Cloud SQL failover experiment against `weekly-tests-sql-*` (REGIONAL HA)
- [ ] Confirm the failover succeeds (primary/standby role swap visible in Cloud Console)